### PR TITLE
Fix Itertools::flatten regression in nightly

### DIFF
--- a/src/bcf/match_variants.rs
+++ b/src/bcf/match_variants.rs
@@ -83,7 +83,7 @@ pub fn match_variants(
             let var = Variant::new(&mut rec, &mut i)?;
             let matching = var.alleles.iter().map(|a| {
                 if let Some(range) = index.range(chrom, pos) {
-                    for v in range.map(|(_, idx_vars)| idx_vars).flatten() {
+                    for v in Itertools::flatten(range.map(|(_, idx_vars)| idx_vars)) {
                         if let Some(id) = var.matches(v, a, max_dist, max_len_diff) {
                             return id as i32;
                         }


### PR DESCRIPTION
This fixes a regression in nightly due to the pending stabilization of `Iterator::flatten`.
See https://github.com/rust-lang/rust/pull/51511 for details.