### PR TITLE
Error handling reloaded

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ tempfile = "3.0"
 rocksdb = "0.11"
 ordered-float = "0.5"
 flate2 = "1.0.5"
-failure = "0.1.5"
+
 
 [[bin]]
 name = "rbt"

--- a/src/fastq/call_consensus_reads/mod.rs
+++ b/src/fastq/call_consensus_reads/mod.rs
@@ -79,32 +79,13 @@ use bio::io::fastq;
 use flate2::bufread::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
+use std::error::Error;
 use std::fs;
 use std::io::BufReader;
-use std::error::Error;
 use std::str;
-use quick_error::quick_error;
-
 
 use pipeline::CallConsensusReads;
 use pipeline::CallNonOverlappingConsensusRead;
-
-
-
-// #[derive(Fail, Debug)]
-// #[fail(
-//     display = "Invalid FASTQ path for parameter {}. Could not open file {}",
-//     _0, _1
-// )]
-// pub struct FastqIOError {
-//     ci_parameter: String,
-//     path: String,
-// }
-
-
-
-
-
 
 /// Build readers for the given input and output FASTQ files and pass them to
 /// `call_consensus_reads`.

--- a/src/fastq/call_consensus_reads/mod.rs
+++ b/src/fastq/call_consensus_reads/mod.rs
@@ -76,26 +76,35 @@ mod calc_consensus;
 mod pipeline;
 
 use bio::io::fastq;
-use failure::{Context, Fail, ResultExt};
 use flate2::bufread::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use std::fs;
 use std::io::BufReader;
+use std::error::Error;
 use std::str;
+use quick_error::quick_error;
+
 
 use pipeline::CallConsensusReads;
 use pipeline::CallNonOverlappingConsensusRead;
 
-#[derive(Fail, Debug)]
-#[fail(
-    display = "Invalid FASTQ path for parameter {}. Could not open file {}",
-    _0, _1
-)]
-pub struct FastqIOError {
-    ci_parameter: String,
-    path: String,
-}
+
+
+// #[derive(Fail, Debug)]
+// #[fail(
+//     display = "Invalid FASTQ path for parameter {}. Could not open file {}",
+//     _0, _1
+// )]
+// pub struct FastqIOError {
+//     ci_parameter: String,
+//     path: String,
+// }
+
+
+
+
+
 
 /// Build readers for the given input and output FASTQ files and pass them to
 /// `call_consensus_reads`.
@@ -110,64 +119,47 @@ pub fn call_consensus_reads_from_paths(
     umi_len: usize,
     seq_dist: usize,
     umi_dist: usize,
-) -> Result<(), Context<FastqIOError>> {
+) -> Result<(), Box<dyn Error>> {
     eprintln!("Reading input files:\n    {}\n    {}", fq1, fq2);
     eprintln!("Writing output to:\n    {}\n    {}", fq1_out, fq2_out);
 
     match (fq1.ends_with(".gz"), fq2.ends_with(".gz"), fq1_out.ends_with(".gz"), fq2_out.ends_with(".gz")) {
-        (false, false, false, false) => match CallNonOverlappingConsensusRead::new(
-            &mut fastq::Reader::from_file(fq1).context(FastqIOError{ci_parameter: "fq1".to_owned(), path: fq1.to_owned()})?,
-            &mut fastq::Reader::from_file(fq2).context(FastqIOError{ci_parameter: "fq2".to_owned(), path: fq2.to_owned()})?,
-            &mut fastq::Writer::to_file(fq1_out).context(FastqIOError{ci_parameter: "fq1_out".to_owned(), path: fq1_out.to_owned()})?,
-            &mut fastq::Writer::to_file(fq2_out).context(FastqIOError{ci_parameter: "fq2_out".to_owned(), path: fq1_out.to_owned()})?,
+        (false, false, false, false) => CallNonOverlappingConsensusRead::new(
+            &mut fastq::Reader::from_file(fq1)?,
+            &mut fastq::Reader::from_file(fq2)?,
+            &mut fastq::Writer::to_file(fq1_out)?,
+            &mut fastq::Writer::to_file(fq2_out)?,
             umi_len,
             seq_dist,
             umi_dist,
-        ).call_consensus_reads() {
-            Ok(()) => Ok(()),
-            // TODO the code below requires more elaborate handling
-            // The errors returned by rustbio do not implement Sync and Send
-            // If that would be the case, we could use
-            // call_consensus_reads().map_err(Error::from_boxed_compat)?
-            // TODO this is a Placeholder Error Type
-            Err(_e) => Err(Context::new(FastqIOError{ci_parameter: "general".to_owned(), path: "general".to_owned()})),
-        },
-        (true, true, false, false) => match CallNonOverlappingConsensusRead::new(
-            &mut fastq::Reader::new(fs::File::open(fq1).map(BufReader::new).map(GzDecoder::new).context(FastqIOError{ci_parameter: "fq1".to_owned(), path: fq1.to_owned()})?),
-            &mut fastq::Reader::new(fs::File::open(fq2).map(BufReader::new).map(GzDecoder::new).context(FastqIOError{ci_parameter: "fq2".to_owned(), path: fq2.to_owned()})?),
-            &mut fastq::Writer::to_file(fq1_out).context(FastqIOError{ci_parameter: "fq1_out".to_owned(), path: fq1_out.to_owned()})?,
-            &mut fastq::Writer::to_file(fq2_out).context(FastqIOError{ci_parameter: "fq2_out".to_owned(), path: fq2_out.to_owned()})?,
+        ).call_consensus_reads(),
+        (true, true, false, false) => CallNonOverlappingConsensusRead::new(
+            &mut fastq::Reader::new(fs::File::open(fq1).map(BufReader::new).map(GzDecoder::new)?),
+            &mut fastq::Reader::new(fs::File::open(fq2).map(BufReader::new).map(GzDecoder::new)?),
+            &mut fastq::Writer::to_file(fq1_out)?,
+            &mut fastq::Writer::to_file(fq2_out)?,
             umi_len,
             seq_dist,
             umi_dist,
-        ).call_consensus_reads() {
-            Ok(()) => Ok(()),
-            Err(_e) => Err(Context::new(FastqIOError{ci_parameter: "general".to_owned(), path: "general".to_owned()})),
-        },
-        (false, false, true, true) => match CallNonOverlappingConsensusRead::new(
-            &mut fastq::Reader::from_file(fq1).context(FastqIOError{ci_parameter: "fq1".to_owned(), path: fq1.to_owned()})?,
-            &mut fastq::Reader::from_file(fq2).context(FastqIOError{ci_parameter: "fq2".to_owned(), path: fq2.to_owned()})?,
-            &mut fastq::Writer::new(GzEncoder::new(fs::File::create(fq1_out).context(FastqIOError{ci_parameter: "fq1_out".to_owned(), path: fq1_out.to_owned()})?, Compression::default())),
-            &mut fastq::Writer::new(GzEncoder::new(fs::File::create(fq2_out).context(FastqIOError{ci_parameter: "fq2_out".to_owned(), path: fq2_out.to_owned()})?, Compression::default())),
+        ).call_consensus_reads(),
+        (false, false, true, true) => CallNonOverlappingConsensusRead::new(
+            &mut fastq::Reader::from_file(fq1)?,
+            &mut fastq::Reader::from_file(fq2)?,
+            &mut fastq::Writer::new(GzEncoder::new(fs::File::create(fq1_out)?, Compression::default())),
+            &mut fastq::Writer::new(GzEncoder::new(fs::File::create(fq2_out)?, Compression::default())),
             umi_len,
             seq_dist,
             umi_dist,
-        ).call_consensus_reads() {
-            Ok(()) => Ok(()),
-            Err(_e) => Err(Context::new(FastqIOError{ci_parameter: "general".to_owned(), path: "general".to_owned()})),
-        },
-        (true, true, true, true) => match CallNonOverlappingConsensusRead::new(
-            &mut fastq::Reader::new(fs::File::open(fq1).map(BufReader::new).map(GzDecoder::new).context(FastqIOError{ci_parameter: "fq1".to_owned(), path: fq1.to_owned()})?),
-            &mut fastq::Reader::new(fs::File::open(fq2).map(BufReader::new).map(GzDecoder::new).context(FastqIOError{ci_parameter: "fq2".to_owned(), path: fq2.to_owned()})?),
-            &mut fastq::Writer::new(GzEncoder::new(fs::File::create(fq1_out).context(FastqIOError{ci_parameter: "fq1_out".to_owned(), path: fq1_out.to_owned()})?, Compression::default())),
-            &mut fastq::Writer::new(GzEncoder::new(fs::File::create(fq2_out).context(FastqIOError{ci_parameter: "fq2_out".to_owned(), path: fq2_out.to_owned()})?, Compression::default())),
+        ).call_consensus_reads(),
+        (true, true, true, true) => CallNonOverlappingConsensusRead::new(
+            &mut fastq::Reader::new(fs::File::open(fq1).map(BufReader::new).map(GzDecoder::new)?),
+            &mut fastq::Reader::new(fs::File::open(fq2).map(BufReader::new).map(GzDecoder::new)?),
+            &mut fastq::Writer::new(GzEncoder::new(fs::File::create(fq1_out)?, Compression::default())),
+            &mut fastq::Writer::new(GzEncoder::new(fs::File::create(fq2_out)?, Compression::default())),
             umi_len,
             seq_dist,
             umi_dist,
-        ).call_consensus_reads() {
-            Ok(()) => Ok(()),
-            Err(_e) => Err(Context::new(FastqIOError{ci_parameter:"general".to_owned(), path: "general".to_owned()})),
-        },
+        ).call_consensus_reads(),
         _ => panic!("Invalid combination of files. Each pair of files (input and output) need to be both gzipped or both not zipped.")
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,10 @@
 //! Documentation for Rust Bio Tools
 use clap::{load_yaml, value_t};
-use log::{error, LevelFilter};
+use log::LevelFilter;
 
 use clap::App;
 use fern;
 use itertools::Itertools;
-use std::process;
 use std::error::Error;
 
 pub mod bam;
@@ -83,5 +82,4 @@ fn main() -> Result<(), Box<dyn Error>> {
         // clap assures that a avalid subcommand is provided
         Ok(())
     }
-    
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,13 @@ use clap::App;
 use fern;
 use itertools::Itertools;
 use std::process;
+use std::error::Error;
 
 pub mod bam;
 pub mod bcf;
 pub mod fastq;
 
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
     let yaml = load_yaml!("cli.yaml");
     let matches = App::from_yaml(yaml)
         .version(env!("CARGO_PKG_VERSION"))
@@ -29,28 +30,22 @@ fn main() {
         .unwrap();
 
     if let Some(matches) = matches.subcommand_matches("fastq-split") {
-        if let Err(e) = fastq::split::split(&matches.values_of("chunks").unwrap().collect_vec()) {
-            error!("{}", e);
-            process::exit(1);
-        }
+        fastq::split::split(&matches.values_of("chunks").unwrap().collect_vec())?;
+        Ok(())
     } else if let Some(matches) = matches.subcommand_matches("fastq-filter") {
-        if let Err(e) = fastq::filter::filter(&matches.value_of("ids").unwrap()) {
-            error!("{}", e);
-            process::exit(1);
-        }
+        fastq::filter::filter(&matches.value_of("ids").unwrap())?;
+        Ok(())
     } else if let Some(matches) = matches.subcommand_matches("bam-depth") {
-        if let Err(e) = bam::depth::depth(
+        bam::depth::depth(
             &matches.value_of("bam-path").unwrap(),
             value_t!(matches, "max-read-length", u32).unwrap_or(1000),
             value_t!(matches, "include-flags", u16).unwrap_or(0),
             value_t!(matches, "exclude-flags", u16).unwrap_or(4 | 256 | 512 | 1024),
             value_t!(matches, "min-mapq", u8).unwrap_or(0),
-        ) {
-            error!("{}", e);
-            process::exit(1);
-        }
+        )?;
+        Ok(())
     } else if let Some(matches) = matches.subcommand_matches("vcf-to-txt") {
-        if let Err(e) = bcf::to_txt::to_txt(
+        bcf::to_txt::to_txt(
             &matches
                 .values_of("info")
                 .map(|values| values.collect_vec())
@@ -60,26 +55,20 @@ fn main() {
                 .map(|values| values.collect_vec())
                 .unwrap_or(vec![]),
             matches.is_present("genotypes"),
-        ) {
-            error!("{}", e);
-            process::exit(1);
-        }
+        )?;
+        Ok(())
     } else if let Some(matches) = matches.subcommand_matches("vcf-match") {
-        if let Err(e) = bcf::match_variants::match_variants(
+        bcf::match_variants::match_variants(
             matches.value_of("vcf").unwrap(),
             value_t!(matches, "max-dist", u32).unwrap_or(20),
             value_t!(matches, "max-len-diff", u32).unwrap_or(10),
-        ) {
-            error!("{}", e);
-            process::exit(1);
-        }
+        )?;
+        Ok(())
     } else if let Some(_) = matches.subcommand_matches("vcf-baf") {
-        if let Err(e) = bcf::baf::calculate_baf() {
-            error!("{}", e);
-            process::exit(1);
-        }
+        bcf::baf::calculate_baf()?;
+        Ok(())
     } else if let Some(matches) = matches.subcommand_matches("call-consensus-reads") {
-        if let Err(e) = fastq::call_consensus_reads::call_consensus_reads_from_paths(
+        fastq::call_consensus_reads::call_consensus_reads_from_paths(
             matches.value_of("fq1").unwrap(),
             matches.value_of("fq2").unwrap(),
             matches.value_of("consensus-fq1").unwrap(),
@@ -87,9 +76,12 @@ fn main() {
             value_t!(matches, "umi-len", usize).unwrap(),
             value_t!(matches, "max-seq-dist", usize).unwrap(),
             value_t!(matches, "max-umi-dist", usize).unwrap(),
-        ) {
-            error!("{}", e);
-            process::exit(1);
-        }
+        )?;
+        Ok(())
+    } else {
+        // This cannot be reached, since the matches step of
+        // clap assures that a avalid subcommand is provided
+        Ok(())
     }
+    
 }


### PR DESCRIPTION
Reverted error handling with the failure crate and refactored the main function to return error. Now errors (and stack traces) reach the terminal.

This PR removes nicely readable error messages for the `call_consensus_reads` tool. These will return after the errors returned by the rust-bio readers/ writers have been reworked.