### PR TITLE
Improved user feedback.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 [dependencies]
 bio = "0.25"
 clap = { version = "2.27", features = ["yaml", "color", "suggestions"]}
+indicatif = "0.11"
 itertools = "0.6"
 log = "0.4.6"
 fern = "0.5.7"


### PR DESCRIPTION
This PR adds user feedback to the call-consensus-reads tool. For the first clustering pass, the number of reads analyzed is shown. In the second clustering the number of processed clusters/ UMIs is reported.

The output is written to stderr, if run in a terminal. If stderr is piped into a file, no output is written.