### PR TITLE
Renamed parameter to avoid confusion with a reverse UMI

### DIFF
--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -158,7 +158,7 @@ subcommands:
             possible_values: ["1", "2", "3", "4", "5", "6", "7", "8"]
             default_value: "2"
             help: Maximum hamming distance between the sequences of any pair of reads in the same cluster.
-        - reverse-umi:
+        - umi-on-reverse:
             long: reverse-umi
             short: u
             help: Set if UMI is on reverse read

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 value_t!(matches, "umi-len", usize).unwrap(),
                 value_t!(matches, "max-seq-dist", usize).unwrap(),
                 value_t!(matches, "max-umi-dist", usize).unwrap(),
-                matches.is_present("reverse-umi"),
+                matches.is_present("umi-on-reverse"),
                 if matches.is_present("insert-size") {
                     Some(value_t!(matches, "insert-size", usize).unwrap())
                 } else {


### PR DESCRIPTION
This PR renames the parameter in call-consensus-reads which is used to denote that the UMI is located on the reverse read. The current name of that parameter (`--reverse-umi`) might be easily confused with other meanings of reverse (like reverse complement etc.).