### PR TITLE
Short consensus names

### DIFF
--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -218,6 +218,9 @@ subcommands:
             long: umi-on-reverse
             short: u
             help: Set if UMI is on reverse read
+        - short-read-names:
+            long: short-read-names
+            help: Only keep the number of reads from which a consensus read was generated in the read name.
         - insert-size:
             long: insert-size
             short: i

--- a/src/fastq/call_consensus_reads/calc_consensus.rs
+++ b/src/fastq/call_consensus_reads/calc_consensus.rs
@@ -15,6 +15,7 @@ pub trait CalcConsensus<'a> {
             .map(|rec| rec.seq().len())
             .all(|len| len == reference_length)
     }
+
     #[allow(unused_doc_comments)]
     /// Compute the likelihood for the given allele and read position.
     /// The allele (A, C, G, or T) is an explicit parameter,
@@ -31,6 +32,7 @@ pub trait CalcConsensus<'a> {
             q + PROB_CONFUSION
         }
     }
+
     fn build_consensus_sequence(
         likelihoods: Vec<LogProb>,
         consensus_lh: &mut LogProb,
@@ -78,9 +80,20 @@ pub struct CalcNonOverlappingConsensus<'a> {
 }
 
 impl<'a> CalcNonOverlappingConsensus<'a> {
-    pub fn new(recs: &'a [fastq::Record], seqids: &'a [usize], uuid: &'a str, short_read_names: bool) -> Self {
-        CalcNonOverlappingConsensus { recs, seqids, uuid, short_read_names }
+    pub fn new(
+        recs: &'a [fastq::Record],
+        seqids: &'a [usize],
+        uuid: &'a str,
+        short_read_names: bool,
+    ) -> Self {
+        CalcNonOverlappingConsensus {
+            recs,
+            seqids,
+            uuid,
+            short_read_names,
+        }
     }
+
     pub fn calc_consensus(&self) -> (fastq::Record, LogProb) {
         let seq_len = self.recs()[0].seq().len();
         let mut consensus_seq: Vec<u8> = Vec::with_capacity(seq_len);
@@ -129,7 +142,7 @@ impl<'a> CalcNonOverlappingConsensus<'a> {
                 "{}_consensus-read-from:{}",
                 self.uuid(),
                 self.seqids().iter().map(|i| format!("{}", i)).join(",")
-            )
+            ),
         };
 
         (
@@ -137,6 +150,7 @@ impl<'a> CalcNonOverlappingConsensus<'a> {
             consensus_lh,
         )
     }
+
     pub fn recs(&self) -> &[fastq::Record] {
         self.recs
     }
@@ -150,9 +164,11 @@ impl<'a> CalcConsensus<'a> for CalcNonOverlappingConsensus<'a> {
         }
         lh
     }
+
     fn seqids(&self) -> &'a [usize] {
         self.seqids
     }
+
     fn uuid(&self) -> &'a str {
         self.uuid
     }
@@ -189,6 +205,7 @@ impl<'a> CalcOverlappingConsensus<'a> {
             uuid,
         }
     }
+
     pub fn calc_consensus(&self) -> (fastq::Record, LogProb) {
         let seq_len = self.recs1()[0].seq().len() + self.recs2()[0].seq().len() - self.overlap();
         let mut consensus_seq: Vec<u8> = Vec::with_capacity(seq_len);
@@ -232,12 +249,15 @@ impl<'a> CalcOverlappingConsensus<'a> {
             consensus_lh,
         )
     }
+
     fn recs1(&self) -> &[fastq::Record] {
         self.recs1
     }
+
     fn recs2(&self) -> &[fastq::Record] {
         self.recs2
     }
+
     fn overlap(&self) -> usize {
         self.overlap
     }
@@ -259,9 +279,11 @@ impl<'a> CalcConsensus<'a> for CalcOverlappingConsensus<'a> {
         }
         lh
     }
+
     fn seqids(&self) -> &'a [usize] {
         self.seqids
     }
+
     fn uuid(&self) -> &'a str {
         self.uuid
     }

--- a/src/fastq/call_consensus_reads/calc_consensus.rs
+++ b/src/fastq/call_consensus_reads/calc_consensus.rs
@@ -74,11 +74,12 @@ pub struct CalcNonOverlappingConsensus<'a> {
     recs: &'a [fastq::Record],
     seqids: &'a [usize],
     uuid: &'a str,
+    short_read_names: bool,
 }
 
 impl<'a> CalcNonOverlappingConsensus<'a> {
-    pub fn new(recs: &'a [fastq::Record], seqids: &'a [usize], uuid: &'a str) -> Self {
-        CalcNonOverlappingConsensus { recs, seqids, uuid }
+    pub fn new(recs: &'a [fastq::Record], seqids: &'a [usize], uuid: &'a str, short_read_names: bool) -> Self {
+        CalcNonOverlappingConsensus { recs, seqids, uuid, short_read_names }
     }
     pub fn calc_consensus(&self) -> (fastq::Record, LogProb) {
         let seq_len = self.recs()[0].seq().len();
@@ -117,11 +118,20 @@ impl<'a> CalcNonOverlappingConsensus<'a> {
                 &mut consensus_qual,
             );
         }
-        let name = format!(
-            "{}_consensus-read-from:{}",
-            self.uuid(),
-            self.seqids().iter().map(|i| format!("{}", i)).join(",")
-        );
+
+        let name = match self.short_read_names {
+            true => format!(
+                "{}_consensus-read-from:{}_reads",
+                self.uuid(),
+                self.seqids().len(),
+            ),
+            false => format!(
+                "{}_consensus-read-from:{}",
+                self.uuid(),
+                self.seqids().iter().map(|i| format!("{}", i)).join(",")
+            )
+        };
+
         (
             fastq::Record::with_attrs(&name, None, &consensus_seq, &consensus_qual),
             consensus_lh,

--- a/src/fastq/call_consensus_reads/mod.rs
+++ b/src/fastq/call_consensus_reads/mod.rs
@@ -100,6 +100,7 @@ pub fn call_consensus_reads_from_paths(
     seq_dist: usize,
     umi_dist: usize,
     reverse_umi: bool,
+    short_read_names: bool,
     insert_size: Option<usize>,
     std_dev: Option<usize>,
 ) -> Result<(), Box<dyn Error>> {
@@ -117,6 +118,7 @@ pub fn call_consensus_reads_from_paths(
                     seq_dist,
                     umi_dist,
                     reverse_umi,
+                    short_read_names,
                 ).call_consensus_reads(),
                 (true, true, false, false) => CallNonOverlappingConsensusRead::new(
                     &mut fastq::Reader::new(fs::File::open(fq1).map(BufReader::new).map(MultiGzDecoder::new)?),
@@ -127,6 +129,7 @@ pub fn call_consensus_reads_from_paths(
                     seq_dist,
                     umi_dist,
                     reverse_umi,
+                    short_read_names,
                 ).call_consensus_reads(),
                 (false, false, true, true) => CallNonOverlappingConsensusRead::new(
                     &mut fastq::Reader::from_file(fq1)?,
@@ -137,6 +140,7 @@ pub fn call_consensus_reads_from_paths(
                     seq_dist,
                     umi_dist,
                     reverse_umi,
+                    short_read_names,
                 ).call_consensus_reads(),
                 (true, true, true, true) => CallNonOverlappingConsensusRead::new(
                     &mut fastq::Reader::new(fs::File::open(fq1).map(BufReader::new).map(MultiGzDecoder::new)?),
@@ -147,6 +151,7 @@ pub fn call_consensus_reads_from_paths(
                     seq_dist,
                     umi_dist,
                     reverse_umi,
+                    short_read_names,
                 ).call_consensus_reads(),
                 _ => panic!("Invalid combination of files. Each pair of files (input and output) need to be both gzipped or both not zipped.")
             }
@@ -170,6 +175,7 @@ pub fn call_consensus_reads_from_paths(
                     insert_size.unwrap(),
                     std_dev.unwrap(),
                     reverse_umi,
+                    short_read_names,
                 ).call_consensus_reads(),
                 (true, true, false, false, false) => CallOverlappingConsensusRead::new(
                     &mut fastq::Reader::new(fs::File::open(fq1).map(BufReader::new).map(MultiGzDecoder::new)?),
@@ -183,6 +189,7 @@ pub fn call_consensus_reads_from_paths(
                     insert_size.unwrap(),
                     std_dev.unwrap(),
                     reverse_umi,
+                    short_read_names,
                 ).call_consensus_reads(),
                 (false, false, true, true, true) => CallOverlappingConsensusRead::new(
                     &mut fastq::Reader::from_file(fq1)?,
@@ -196,6 +203,7 @@ pub fn call_consensus_reads_from_paths(
                     insert_size.unwrap(),
                     std_dev.unwrap(),
                     reverse_umi,
+                    short_read_names,
                 ).call_consensus_reads(),
                 (true, true, true, true, true) => CallOverlappingConsensusRead::new(
                     &mut fastq::Reader::new(fs::File::open(fq1).map(BufReader::new).map(MultiGzDecoder::new)?),
@@ -209,6 +217,7 @@ pub fn call_consensus_reads_from_paths(
                     insert_size.unwrap(),
                     std_dev.unwrap(),
                     reverse_umi,
+                    short_read_names,
                 ).call_consensus_reads(),
                 _ => panic!("Invalid combination of files. Each pair of files (input and output) need to be both gzipped or both not zipped.")
             }

--- a/src/fastq/call_consensus_reads/pipeline.rs
+++ b/src/fastq/call_consensus_reads/pipeline.rs
@@ -170,14 +170,14 @@ pub trait CallConsensusReads<'a, R: io::Read + 'a, W: io::Write + 'a> {
             pb.inc(1);
             self.fq1_reader().read(&mut f_rec)?;
             self.fq2_reader().read(&mut r_rec)?;
-            
+
             match (f_rec.is_empty(), r_rec.is_empty()) {
                 (true, true) => break,
                 (false, false) => (),
                 (true, false) => {
                     let error_message = format!("Given FASTQ files have unequal lengths. Forward file returned record {} as empty, reverse record is not: id:'{}' seq:'{:?}'.", i, r_rec.id(), str::from_utf8(r_rec.seq()));
                     panic!(error_message);
-                },
+                }
                 (false, true) => {
                     let error_message = format!("Given FASTQ files have unequal lengths. Reverse file returned record {} as empty, forward record is not: id:'{}' seq:'{:?}'.", i, f_rec.id(), str::from_utf8(f_rec.seq()));
                     panic!(error_message);
@@ -353,14 +353,24 @@ impl<'a, R: io::Read, W: io::Write> CallConsensusReads<'a, R, W>
         if f_recs.len() > 1 {
             let uuid = &Uuid::new_v4().to_hyphenated().to_string();
             self.fq1_writer.write_record(
-                &CalcNonOverlappingConsensus::new(&f_recs, &outer_seqids, uuid, self.short_read_names)
-                    .calc_consensus()
-                    .0,
+                &CalcNonOverlappingConsensus::new(
+                    &f_recs,
+                    &outer_seqids,
+                    uuid,
+                    self.short_read_names,
+                )
+                .calc_consensus()
+                .0,
             )?;
             self.fq2_writer.write_record(
-                &CalcNonOverlappingConsensus::new(&r_recs, &outer_seqids, uuid, self.short_read_names)
-                    .calc_consensus()
-                    .0,
+                &CalcNonOverlappingConsensus::new(
+                    &r_recs,
+                    &outer_seqids,
+                    uuid,
+                    self.short_read_names,
+                )
+                .calc_consensus()
+                .0,
             )?;
         } else {
             self.fq1_writer.write_record(&f_recs[0])?;
@@ -368,21 +378,27 @@ impl<'a, R: io::Read, W: io::Write> CallConsensusReads<'a, R, W>
         }
         Ok(())
     }
+
     fn fq1_reader(&mut self) -> &mut fastq::Reader<R> {
         &mut self.fq1_reader
     }
+
     fn fq2_reader(&mut self) -> &mut fastq::Reader<R> {
         &mut self.fq2_reader
     }
+
     fn umi_len(&self) -> usize {
         self.umi_len
     }
+
     fn seq_dist(&self) -> usize {
         self.seq_dist
     }
+
     fn umi_dist(&self) -> usize {
         self.umi_dist
     }
+
     fn reverse_umi(&self) -> bool {
         self.reverse_umi
     }
@@ -435,6 +451,7 @@ impl<'a, R: io::Read, W: io::Write> CallOverlappingConsensusRead<'a, R, W> {
             short_read_names,
         }
     }
+
     fn isize_highest_probability(&mut self, f_seq_len: usize, r_seq_len: usize) -> f64 {
         if f_seq_len + f_seq_len < self.insert_size {
             return self.insert_size as f64;
@@ -444,6 +461,7 @@ impl<'a, R: io::Read, W: io::Write> CallOverlappingConsensusRead<'a, R, W> {
             return (f_seq_len + r_seq_len) as f64;
         }
     }
+
     fn maximum_likelihood_overlapping_consensus(
         &mut self,
         f_recs: &Vec<Record>,
@@ -481,6 +499,7 @@ impl<'a, R: io::Read, W: io::Write> CallOverlappingConsensusRead<'a, R, W> {
             .max_by_key(|consensus| NotNaN::new(*consensus.likelihood).unwrap())
             .unwrap()
     }
+
     fn maximum_likelihood_nonoverlapping_consensus(
         &mut self,
         f_recs: &Vec<Record>,
@@ -490,9 +509,11 @@ impl<'a, R: io::Read, W: io::Write> CallOverlappingConsensusRead<'a, R, W> {
     ) -> NonOverlappingConsensus {
         //Calculate non-overlapping consensus records and shared lh
         let (f_consensus_rec, f_lh) =
-            CalcNonOverlappingConsensus::new(&f_recs, &outer_seqids, uuid, self.short_read_names).calc_consensus();
+            CalcNonOverlappingConsensus::new(&f_recs, &outer_seqids, uuid, self.short_read_names)
+                .calc_consensus();
         let (r_consensus_rec, r_lh) =
-            CalcNonOverlappingConsensus::new(&r_recs, &outer_seqids, uuid, self.short_read_names).calc_consensus();
+            CalcNonOverlappingConsensus::new(&r_recs, &outer_seqids, uuid, self.short_read_names)
+                .calc_consensus();
         let overall_lh_isize = f_lh + r_lh;
         //Determine insert size with highest probability for non-overlapping records based on expected insert size
         let likeliest_isize =
@@ -535,21 +556,27 @@ impl<'a, R: io::Read, W: io::Write> CallConsensusReads<'a, R, W>
         }
         Ok(())
     }
+
     fn fq1_reader(&mut self) -> &mut fastq::Reader<R> {
         &mut self.fq1_reader
     }
+
     fn fq2_reader(&mut self) -> &mut fastq::Reader<R> {
         &mut self.fq2_reader
     }
+
     fn umi_len(&self) -> usize {
         self.umi_len
     }
+
     fn seq_dist(&self) -> usize {
         self.seq_dist
     }
+
     fn umi_dist(&self) -> usize {
         self.umi_dist
     }
+
     fn reverse_umi(&self) -> bool {
         self.reverse_umi
     }

--- a/src/fastq/call_consensus_reads/pipeline.rs
+++ b/src/fastq/call_consensus_reads/pipeline.rs
@@ -312,6 +312,7 @@ pub struct CallNonOverlappingConsensusRead<'a, R: io::Read, W: io::Write> {
     seq_dist: usize,
     umi_dist: usize,
     reverse_umi: bool,
+    short_read_names: bool,
 }
 
 impl<'a, R: io::Read, W: io::Write> CallNonOverlappingConsensusRead<'a, R, W> {
@@ -324,6 +325,7 @@ impl<'a, R: io::Read, W: io::Write> CallNonOverlappingConsensusRead<'a, R, W> {
         seq_dist: usize,
         umi_dist: usize,
         reverse_umi: bool,
+        short_read_names: bool,
     ) -> Self {
         CallNonOverlappingConsensusRead {
             fq1_reader,
@@ -334,6 +336,7 @@ impl<'a, R: io::Read, W: io::Write> CallNonOverlappingConsensusRead<'a, R, W> {
             seq_dist,
             umi_dist,
             reverse_umi,
+            short_read_names,
         }
     }
 }
@@ -350,12 +353,12 @@ impl<'a, R: io::Read, W: io::Write> CallConsensusReads<'a, R, W>
         if f_recs.len() > 1 {
             let uuid = &Uuid::new_v4().to_hyphenated().to_string();
             self.fq1_writer.write_record(
-                &CalcNonOverlappingConsensus::new(&f_recs, &outer_seqids, uuid)
+                &CalcNonOverlappingConsensus::new(&f_recs, &outer_seqids, uuid, self.short_read_names)
                     .calc_consensus()
                     .0,
             )?;
             self.fq2_writer.write_record(
-                &CalcNonOverlappingConsensus::new(&r_recs, &outer_seqids, uuid)
+                &CalcNonOverlappingConsensus::new(&r_recs, &outer_seqids, uuid, self.short_read_names)
                     .calc_consensus()
                     .0,
             )?;
@@ -399,6 +402,7 @@ pub struct CallOverlappingConsensusRead<'a, R: io::Read, W: io::Write> {
     insert_size: usize,
     std_dev: usize,
     reverse_umi: bool,
+    short_read_names: bool,
 }
 
 impl<'a, R: io::Read, W: io::Write> CallOverlappingConsensusRead<'a, R, W> {
@@ -414,6 +418,7 @@ impl<'a, R: io::Read, W: io::Write> CallOverlappingConsensusRead<'a, R, W> {
         insert_size: usize,
         std_dev: usize,
         reverse_umi: bool,
+        short_read_names: bool,
     ) -> Self {
         CallOverlappingConsensusRead {
             fq1_reader,
@@ -427,6 +432,7 @@ impl<'a, R: io::Read, W: io::Write> CallOverlappingConsensusRead<'a, R, W> {
             insert_size,
             std_dev,
             reverse_umi,
+            short_read_names,
         }
     }
     fn isize_highest_probability(&mut self, f_seq_len: usize, r_seq_len: usize) -> f64 {
@@ -484,9 +490,9 @@ impl<'a, R: io::Read, W: io::Write> CallOverlappingConsensusRead<'a, R, W> {
     ) -> NonOverlappingConsensus {
         //Calculate non-overlapping consensus records and shared lh
         let (f_consensus_rec, f_lh) =
-            CalcNonOverlappingConsensus::new(&f_recs, &outer_seqids, uuid).calc_consensus();
+            CalcNonOverlappingConsensus::new(&f_recs, &outer_seqids, uuid, self.short_read_names).calc_consensus();
         let (r_consensus_rec, r_lh) =
-            CalcNonOverlappingConsensus::new(&r_recs, &outer_seqids, uuid).calc_consensus();
+            CalcNonOverlappingConsensus::new(&r_recs, &outer_seqids, uuid, self.short_read_names).calc_consensus();
         let overall_lh_isize = f_lh + r_lh;
         //Determine insert size with highest probability for non-overlapping records based on expected insert size
         let likeliest_isize =

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 value_t!(matches, "max-seq-dist", usize).unwrap(),
                 value_t!(matches, "max-umi-dist", usize).unwrap(),
                 matches.is_present("umi-on-reverse"),
+                matches.is_present("short-read-names"),
                 if matches.is_present("insert-size") {
                     Some(value_t!(matches, "insert-size", usize).unwrap())
                 } else {


### PR DESCRIPTION
This PR adds the `--short-read-names` option to `call-consensus-reads` which writes shorter read names for consensus reads. Until now, all reads that were merged into one consensus read were appended to a uuid as a comma separated list. However, some tools, (e.g. stacks), do not cope well with long name line sin fastq files.

When the `--short-read-names` is passed, 
```
@b82e0403-420e-4cdb-a1b7-82b2fc867137_consensus-read-from:1,2,3, ..., 1024
```
will be replaced by
```
@b82e0403-420e-4cdb-a1b7-82b2fc867137_consensus-read-from:420_reads
```
where 420 is the number of reads in the cluster.