### PR TITLE
Chunkwise api requests in annotate-dgidb subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.DS_store

--- a/src/bcf/annotate_dgidb.rs
+++ b/src/bcf/annotate_dgidb.rs
@@ -33,7 +33,7 @@ pub fn annotate_dgidb(
     vcf_path: &str,
     api_path: String,
     field_name: &str,
-    genes_per_request: usize
+    genes_per_request: usize,
 ) -> Result<(), Box<dyn Error>> {
     let gene_drug_interactions = request_interaction_drugs(vcf_path, api_path, genes_per_request)?;
     modify_vcf_entries(vcf_path, gene_drug_interactions, field_name)
@@ -42,14 +42,19 @@ pub fn annotate_dgidb(
 fn request_interaction_drugs(
     vcf_path: &str,
     api_path: String,
-    genes_per_request: usize
+    genes_per_request: usize,
 ) -> Result<Option<HashMap<String, Vec<(String, Vec<String>)>>>, Box<dyn Error>> {
     let mut genes = collect_genes(vcf_path)?;
     if genes.is_empty() {
         return Ok(None);
     }
     let mut gene_drug_interactions: HashMap<String, Vec<(String, Vec<String>)>> = HashMap::new();
-    for gene_slice in genes.drain().map(|gene| gene).collect_vec().chunks(genes_per_request) {
+    for gene_slice in genes
+        .drain()
+        .map(|gene| gene)
+        .collect_vec()
+        .chunks(genes_per_request)
+    {
         let mut slice_api_path = api_path.clone();
         slice_api_path.push_str(gene_slice.join(",").as_str());
         let res: Dgidb = reqwest::get(&slice_api_path)?.json()?;

--- a/src/bcf/annotate_dgidb.rs
+++ b/src/bcf/annotate_dgidb.rs
@@ -33,37 +33,42 @@ pub fn annotate_dgidb(
     vcf_path: &str,
     api_path: String,
     field_name: &str,
+    genes_per_request: usize
 ) -> Result<(), Box<dyn Error>> {
-    let gene_drug_interactions = request_interaction_drugs(vcf_path, api_path)?;
+    let gene_drug_interactions = request_interaction_drugs(vcf_path, api_path, genes_per_request)?;
     modify_vcf_entries(vcf_path, gene_drug_interactions, field_name)
 }
 
 fn request_interaction_drugs(
     vcf_path: &str,
-    mut api_path: String,
+    api_path: String,
+    genes_per_request: usize
 ) -> Result<Option<HashMap<String, Vec<(String, Vec<String>)>>>, Box<dyn Error>> {
     let mut genes = collect_genes(vcf_path)?;
     if genes.is_empty() {
         return Ok(None);
     }
-    api_path.push_str(genes.drain().join(",").as_str());
-    let res: Dgidb = reqwest::get(&api_path)?.json()?;
-
     let mut gene_drug_interactions: HashMap<String, Vec<(String, Vec<String>)>> = HashMap::new();
-    for term in res.matched_terms {
-        if !term.interactions.is_empty() {
-            gene_drug_interactions.insert(
-                term.gene_name,
-                term.interactions
-                    .iter()
-                    .map(|interaction| {
-                        (
-                            interaction.drug_name.clone(),
-                            interaction.interaction_types.clone(),
-                        )
-                    })
-                    .collect(),
-            );
+    for gene_slice in genes.drain().map(|gene| gene).collect_vec().chunks(genes_per_request) {
+        let mut slice_api_path = api_path.clone();
+        slice_api_path.push_str(gene_slice.join(",").as_str());
+        let res: Dgidb = reqwest::get(&slice_api_path)?.json()?;
+
+        for term in res.matched_terms {
+            if !term.interactions.is_empty() {
+                gene_drug_interactions.insert(
+                    term.gene_name,
+                    term.interactions
+                        .iter()
+                        .map(|interaction| {
+                            (
+                                interaction.drug_name.clone(),
+                                interaction.interaction_types.clone(),
+                            )
+                        })
+                        .collect(),
+                );
+            }
         }
     }
     Ok(Some(gene_drug_interactions))

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -181,7 +181,7 @@ subcommands:
           - genes-per-request:
               long: genes-per-request
               short: g
-              default_value: 1000
+              default_value: "1000"
               help: Number of genes to submit per api request.
         author: Felix Mölder <felix.moelder@uni-due.de>
 

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -166,14 +166,23 @@ subcommands:
                 rbt vcf-annotate-dgidb input.vcf > output.vcf
         args:
           - vcf:
-                required: true
-                help: VCF/BCF file to be extended by dgidb drug entries
+              required: true
+              help: VCF/BCF file to be extended by dgidb drug entries
           - api-path:
-                default_value: "http://dgidb.org/api/v2/interactions.json?genes="
-                help: "url prefix for requesting interaction drugs by gene names."
+              long: api-path
+              short: p
+              default_value: http://dgidb.org/api/v2/interactions.json?genes=
+              help: url prefix for requesting interaction drugs by gene names.
           - field:
-              default_value: "dgiDB_drugs"
-              help: "Info field name to be used for annotation"
+              long: field
+              short: f
+              default_value: dgiDB_drugs
+              help: Info field name to be used for annotation.
+          - genes-per-request:
+              long: genes-per-request
+              short: g
+              default_value: 1000
+              help: Number of genes to submit per api request.
         author: Felix Mölder <felix.moelder@uni-due.de>
 
   - call-consensus-reads:

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -182,7 +182,8 @@ subcommands:
               long: genes-per-request
               short: g
               default_value: "1000"
-              help: Number of genes to submit per api request.
+              help: Number of genes to submit per api request. A lower value increases the number of api requests in return. 
+                    Too many requests could be rejected by the DGIdb server.
         author: Felix Mölder <felix.moelder@uni-due.de>
 
   - call-consensus-reads:

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             &matches.value_of("vcf").unwrap(),
             matches.value_of("api-path").unwrap().to_string(),
             &matches.value_of("field").unwrap(),
+            value_t!(matches, "genes-per-request", usize).unwrap()
         ),
         ("call-consensus-reads", Some(matches)) => match matches.subcommand() {
             ("fastq", Some(matches)) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             &matches.value_of("vcf").unwrap(),
             matches.value_of("api-path").unwrap().to_string(),
             &matches.value_of("field").unwrap(),
-            value_t!(matches, "genes-per-request", usize).unwrap()
+            value_t!(matches, "genes-per-request", usize).unwrap(),
         ),
         ("call-consensus-reads", Some(matches)) => match matches.subcommand() {
             ("fastq", Some(matches)) => {


### PR DESCRIPTION
This PR fixes a bug where annotation of dgidb interaction drugs fails if the input vcf contains too many genes.
The error originates from a too long url, build from the genes contained in the vcf file.
To resolve this issue the subcommand now performs multiple api requests instead of a single one, only submitting 1000 genes per request.

To circumvent future issues the subcommand now also has a new parameter `genes-per-requests` allowing to adjust the number of genes being submitted by each request.
This value should be as high as possible for keeping the number of requests low.