### PR TITLE
Fixed syntax of call-consensus-reads usage examples

### DIFF
--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -207,7 +207,7 @@ subcommands:
                 - UMI is the prefix of the reads
 
               Example:
-              rbt call-consensus-reads \
+              rbt call-consensus-reads fastq \
                 reads_1.fq reads_2.fq \    # input files
                 merged_1.fq merged_2.fq \  # output files
                 -l 13 \                    # length of UMI

--- a/src/fastq/call_consensus_reads/mod.rs
+++ b/src/fastq/call_consensus_reads/mod.rs
@@ -13,7 +13,7 @@
 //! ## Usage:
 //!
 //! ```bash
-//! $ rbt call-consensus-reads \
+//! $ rbt call-consensus-reads fastq \
 //!   <Path to FASTQ file with forward reads> \
 //!   <Path to FASTQ file with reverse reads> \
 //!   <Path for output forward FASTQ file> \


### PR DESCRIPTION
Since the bam version of call-consensus-read has been added, an additional subcommand is required.