### PR TITLE
Reduced number of genes per request

### DIFF
--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -190,7 +190,7 @@ subcommands:
           - genes-per-request:
               long: genes-per-request
               short: g
-              default_value: "1000"
+              default_value: "500"
               help: Number of genes to submit per api request. A lower value increases the number of api requests in return. 
                     Too many requests could be rejected by the DGIdb server.
         author: Felix Mölder <felix.moelder@uni-due.de>


### PR DESCRIPTION
This PR reduces the number of genes submitted per dgidb-api request to 500.
It showed, that submitting 1000 genes at once may return a http-request error.
To ensure that the gene-string does not exceed the request limitations the number of genes has been reduced.