### PR TITLE
Oncoprint: Parse ANN field as defined by VEP

### DIFF
--- a/src/bcf/oncoprint.rs
+++ b/src/bcf/oncoprint.rs
@@ -12,7 +12,10 @@ use tera::{self, Context, Tera};
 
 use rust_htslib::bcf::{self, Read};
 
-pub fn oncoprint(sample_calls: &HashMap<String, String>, vep_annotation: bool) -> Result<(), Box<dyn Error>> {
+pub fn oncoprint(
+    sample_calls: &HashMap<String, String>,
+    vep_annotation: bool,
+) -> Result<(), Box<dyn Error>> {
     let mut data = HashMap::new();
     for (sample, path) in sample_calls.iter().sorted() {
         let mut genes = HashMap::new();
@@ -55,8 +58,16 @@ pub fn oncoprint(sample_calls: &HashMap<String, String>, vep_annotation: bool) -
                         }
 
                         let gene = str::from_utf8(fields[3])?;
-                        let dna_alteration = if vep_annotation {str::from_utf8(fields[10])?} else {str::from_utf8(fields[9])? };
-                        let protein_alteration = if vep_annotation {str::from_utf8(fields[11])?} else {str::from_utf8(fields[10])? };
+                        let dna_alteration = if vep_annotation {
+                            str::from_utf8(fields[10])?
+                        } else {
+                            str::from_utf8(fields[9])?
+                        };
+                        let protein_alteration = if vep_annotation {
+                            str::from_utf8(fields[11])?
+                        } else {
+                            str::from_utf8(fields[10])?
+                        };
 
                         let rec = genes
                             .entry(gene.to_owned())

--- a/src/bcf/oncoprint.rs
+++ b/src/bcf/oncoprint.rs
@@ -12,7 +12,7 @@ use tera::{self, Context, Tera};
 
 use rust_htslib::bcf::{self, Read};
 
-pub fn oncoprint(sample_calls: &HashMap<String, String>) -> Result<(), Box<dyn Error>> {
+pub fn oncoprint(sample_calls: &HashMap<String, String>, vep_annotation: bool) -> Result<(), Box<dyn Error>> {
     let mut data = HashMap::new();
     for (sample, path) in sample_calls.iter().sorted() {
         let mut genes = HashMap::new();
@@ -55,8 +55,8 @@ pub fn oncoprint(sample_calls: &HashMap<String, String>) -> Result<(), Box<dyn E
                         }
 
                         let gene = str::from_utf8(fields[3])?;
-                        let dna_alteration = str::from_utf8(fields[9])?;
-                        let protein_alteration = str::from_utf8(fields[10])?;
+                        let dna_alteration = if vep_annotation {str::from_utf8(fields[10])?} else {str::from_utf8(fields[9])? };
+                        let protein_alteration = if vep_annotation {str::from_utf8(fields[11])?} else {str::from_utf8(fields[10])? };
 
                         let rec = genes
                             .entry(gene.to_owned())

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -208,6 +208,9 @@ subcommands:
             multiple: true
             value_name: NAME=FILE
             help: VCF/BCF files to include (single-sample). Name is the sample name that will be used in the oncoprint.
+        - vep-annotation:
+            long: vep-annotation
+            help: Annotation field gets parsed as definded by VEP.
 
   - collapse-reads-to-fragments:
       about: |

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,10 +74,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 sample_calls.insert(e[0].to_owned(), e[1].to_owned());
             }
 
-            bcf::oncoprint::oncoprint(
-                &sample_calls,
-                matches.is_present("vep-annotation")
-            )
+            bcf::oncoprint::oncoprint(&sample_calls, matches.is_present("vep-annotation"))
         }
         ("collapse-reads-to-fragments", Some(matches)) => match matches.subcommand() {
             ("fastq", Some(matches)) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,10 @@ fn main() -> Result<(), Box<dyn Error>> {
                 sample_calls.insert(e[0].to_owned(), e[1].to_owned());
             }
 
-            bcf::oncoprint::oncoprint(&sample_calls)
+            bcf::oncoprint::oncoprint(
+                &sample_calls,
+                matches.is_present("vep-annotation")
+            )
         }
         ("collapse-reads-to-fragments", Some(matches)) => match matches.subcommand() {
             ("fastq", Some(matches)) => {


### PR DESCRIPTION
This adds a flag `--vep-annotation` to the oncoprint submodule allowing to correctly parse bcf-files annotated by VEP.