### PR TITLE
Fix report test

### DIFF
--- a/tests/expected/report/details/a/KRAS.html
+++ b/tests/expected/report/details/a/KRAS.html
@@ -19,7 +19,6 @@
     <div class="collapse navbar-collapse" id="navbarText">
         <ul class="navbar-nav mr-auto">
             <li class="nav-item">
-                <a class="nav-link" href="https://github.com/rust-bio/rust-bio-tools/blob/master/CHANGELOG.md">0.11.1-alpha.0</a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="https://github.com/rust-bio/rust-bio-tools">github</a>

--- a/tests/expected/report/details/b/KRAS.html
+++ b/tests/expected/report/details/b/KRAS.html
@@ -19,7 +19,6 @@
     <div class="collapse navbar-collapse" id="navbarText">
         <ul class="navbar-nav mr-auto">
             <li class="nav-item">
-                <a class="nav-link" href="https://github.com/rust-bio/rust-bio-tools/blob/master/CHANGELOG.md">0.11.1-alpha.0</a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="https://github.com/rust-bio/rust-bio-tools">github</a>

--- a/tests/expected/report/genes/KRAS1.html
+++ b/tests/expected/report/genes/KRAS1.html
@@ -12,7 +12,6 @@
         <div class="collapse navbar-collapse" id="navbarText">
             <ul class="navbar-nav mr-auto">
                 <li class="nav-item">
-                    <a class="nav-link" href="https://github.com/rust-bio/rust-bio-tools/blob/master/CHANGELOG.md">0.11.1-alpha.0</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" href="https://github.com/rust-bio/rust-bio-tools">github</a>

--- a/tests/expected/report/indexes/index1.html
+++ b/tests/expected/report/indexes/index1.html
@@ -12,7 +12,6 @@
             <div class="collapse navbar-collapse" id="navbarText">
                 <ul class="navbar-nav mr-auto">
                     <li class="nav-item">
-                        <a class="nav-link" href="https://github.com/rust-bio/rust-bio-tools/blob/master/CHANGELOG.md">0.11.1-alpha.0</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="https://github.com/rust-bio/rust-bio-tools">github</a>

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -188,11 +188,11 @@ fn test_vcf_report() {
     ];
 
     for (result, expected) in files1 {
-        // delete line 22 with timestamp
+        // delete line 22 with timestamp and 15 with version
         // this may fail on OS X due to the wrong sed being installed
         assert!(Command::new("bash")
             .arg("-c")
-            .arg("sed -i '22d' ".to_owned() + result)
+            .arg("sed -i '22d;15d' ".to_owned() + result)
             .spawn()
             .unwrap()
             .wait()
@@ -201,11 +201,11 @@ fn test_vcf_report() {
         test_output(result, expected)
     }
     for (result, expected) in files2 {
-        // delete line 29 with timestamp
+        // delete line 29 with timestamp and 22 with version
         // this may fail on OS X due to the wrong sed being installed
         assert!(Command::new("bash")
             .arg("-c")
-            .arg("sed -i '29d' ".to_owned() + result)
+            .arg("sed -i '29d;22d' ".to_owned() + result)
             .spawn()
             .unwrap()
             .wait()


### PR DESCRIPTION
Updating the version of rbt led to problems with the test for the vcf-report since the version is rendered into the navbar of all HTML files and the expected files still had a previous version in their navbar. This PR removes the version from the navbar of the expected files and also adjusts the test accordingly. 