### PR TITLE
Improve format tag data structure

### DIFF
--- a/src/bcf/report/js/table-report.js
+++ b/src/bcf/report/js/table-report.js
@@ -23,7 +23,6 @@ $(document).ready(function () {
 
         for (let t = 1; t <= vis_len; t++) {
             let specs = $(this).data('vis' + t.toString());
-            console.log(specs);
             specs.data[1].values.forEach(function(a) {
                 if (a.row > 0 && Array.isArray(a.flags)) {
                     let flags = {};

--- a/src/bcf/report/mod.rs
+++ b/src/bcf/report/mod.rs
@@ -29,7 +29,6 @@ pub fn embed_js(
             include_str!("js/bootstrap-table.min.js"),
         ),
         ("table-report.js", include_str!("js/table-report.js")),
-        ("report.js", include_str!("js/report.js")),
         ("gene-report.js", include_str!("js/gene-report.js")),
     ];
     if let Some(path) = custom_table_report_js {

--- a/src/bcf/report/mod.rs
+++ b/src/bcf/report/mod.rs
@@ -28,7 +28,7 @@ pub fn embed_js(
             "bootstrap-table.min.js",
             include_str!("js/bootstrap-table.min.js"),
         ),
-        ("table-report.js", include_str!("js/table-report.js")),
+        ("report.js", include_str!("js/report.js")),
         ("gene-report.js", include_str!("js/gene-report.js")),
     ];
     if let Some(path) = custom_table_report_js {
@@ -37,10 +37,10 @@ pub fn embed_js(
         custom_file
             .read_to_string(&mut file_string)
             .expect("Unable to read string");
-        let mut out_file = File::create(js_path.to_owned() + "report.js")?;
+        let mut out_file = File::create(js_path.to_owned() + "table-report.js")?;
         out_file.write_all(file_string.as_bytes())?;
     } else {
-        files.push(("report.js", include_str!("js/report.js")))
+        files.push(("report.js", include_str!("js/table-report.js")))
     }
     for (name, file) in files {
         let mut out_file = File::create(js_path.to_owned() + name)?;

--- a/src/bcf/report/table_report/create_report_table.rs
+++ b/src/bcf/report/table_report/create_report_table.rs
@@ -49,9 +49,11 @@ pub(crate) fn make_table_report(
     let header = vcf.header().clone();
     let header_records = header.header_records();
     let ann_field_description: Vec<_> = get_ann_description(header_records).unwrap();
-    let samples = header.samples().iter().map(|s| {
-        str::from_utf8(s).map(|s| s.to_owned())
-    }).collect::<Result<_, _>>()?;
+    let samples: Vec<_> = header
+        .samples()
+        .iter()
+        .map(|s| std::str::from_utf8(s).map(|s| s.to_owned()))
+        .collect::<Result<_, _>>()?;
 
     for (i, field) in ann_field_description.iter().enumerate() {
         ann_indices.insert(field, i);

--- a/src/bcf/report/table_report/create_report_table.rs
+++ b/src/bcf/report/table_report/create_report_table.rs
@@ -49,10 +49,9 @@ pub(crate) fn make_table_report(
     let header = vcf.header().clone();
     let header_records = header.header_records();
     let ann_field_description: Vec<_> = get_ann_description(header_records).unwrap();
-    let mut samples = Vec::new();
-    for s in header.samples() {
-        samples.push(String::from_utf8(s.to_vec())?);
-    }
+    let samples = header.samples().iter().map(|s| {
+        str::from_utf8(s).map(|s| s.to_owned())
+    }).collect::<Result<_, _>>()?;
 
     for (i, field) in ann_field_description.iter().enumerate() {
         ann_indices.insert(field, i);

--- a/src/bcf/report/table_report/create_report_table.rs
+++ b/src/bcf/report/table_report/create_report_table.rs
@@ -49,6 +49,10 @@ pub(crate) fn make_table_report(
     let header = vcf.header().clone();
     let header_records = header.header_records();
     let ann_field_description: Vec<_> = get_ann_description(header_records).unwrap();
+    let mut samples = Vec::new();
+    for s in header.samples() {
+        samples.push(String::from_utf8(s.to_vec())?);
+    }
 
     for (i, field) in ann_field_description.iter().enumerate() {
         ann_indices.insert(field, i);
@@ -116,26 +120,32 @@ pub(crate) fn make_table_report(
                 match tag_type {
                     TagType::String => {
                         let values = variant.format(tag.as_bytes()).string()?;
-                        for v in values {
+                        for (i, v) in values.into_iter().enumerate() {
                             let value = String::from_utf8(v.to_owned())?;
-                            let entry = format_map.entry(tag.to_owned()).or_insert_with(Vec::new);
-                            entry.push(json!(value));
+                            let entry = format_map
+                                .entry(tag.to_owned())
+                                .or_insert_with(HashMap::new);
+                            entry.insert(samples[i].clone(), json!(value));
                         }
                     }
                     TagType::Float => {
                         let values = variant.format(tag.as_bytes()).float()?;
-                        for v in values {
+                        for (i, v) in values.iter().enumerate() {
                             let value = v.to_vec();
-                            let entry = format_map.entry(tag.to_owned()).or_insert_with(Vec::new);
-                            entry.push(json!(value));
+                            let entry = format_map
+                                .entry(tag.to_owned())
+                                .or_insert_with(HashMap::new);
+                            entry.insert(samples[i].clone(), json!(value));
                         }
                     }
                     TagType::Integer => {
                         let values = variant.format(tag.as_bytes()).integer()?;
-                        for v in values {
+                        for (i, v) in values.iter().enumerate() {
                             let value = v.to_vec();
-                            let entry = format_map.entry(tag.to_owned()).or_insert_with(Vec::new);
-                            entry.push(json!(value));
+                            let entry = format_map
+                                .entry(tag.to_owned())
+                                .or_insert_with(HashMap::new);
+                            entry.insert(samples[i].clone(), json!(value));
                         }
                     }
                     _ => {}


### PR DESCRIPTION
This PR improves and simplifies the use of format tags in the custom JS file given by the user. With the lately added interface for multi-sample vcf-files, the `data-format` attribute was not updated. Now format values eg. `OBS` can be dressed in the JS in the the following way: `$(this).data("format")["OBS"][samplename]`. 