### PR TITLE
Allow INFO-Field prefixes in vcf-report

### DIFF
--- a/src/bcf/report/table_report/create_report_table.rs
+++ b/src/bcf/report/table_report/create_report_table.rs
@@ -96,6 +96,12 @@ pub(crate) fn make_table_report(
         let info_tags = if infos.is_some() {
             let mut info_map = HashMap::new();
             for tag in infos.clone().unwrap() {
+                if tag.chars().last().unwrap().eq(&'*') {
+                    let tags = header.header_records().iter().filter(|header_record| match header_record {
+                        HeaderRecord::Info{key, values: _} => {key.starts_with(&tag[..(tag.len()-1)])},
+                        _ => false
+                    }).map(|header_rec| matheader_rec.key).collect::<Vec<String>>();
+                }
                 let (tag_type, _) = header.info_type(tag.as_bytes())?;
                 match tag_type {
                     TagType::String => {

--- a/src/bcf/report/table_report/create_report_table.rs
+++ b/src/bcf/report/table_report/create_report_table.rs
@@ -404,7 +404,7 @@ pub(crate) fn get_ann_description(header_records: Vec<HeaderRecord>) -> Option<V
 }
 
 fn read_bcf_record(
-    info_map: &mut HashMap<String, Vec<tera::Value>>,
+    info_map: &mut HashMap<String, Vec<Value>>,
     variant: &mut Record,
     header: &HeaderView,
     tag: &str,

--- a/src/bcf/report/table_report/create_report_table.rs
+++ b/src/bcf/report/table_report/create_report_table.rs
@@ -101,9 +101,9 @@ pub(crate) fn make_table_report(
                         .header_records()
                         .iter()
                         .filter_map(|header_record| match header_record {
-                            HeaderRecord::Info { key, values: _ } => {
-                                if key.starts_with(&tag[..(tag.len() - 1)]) {
-                                    Some(key.clone())
+                            HeaderRecord::Info { key: _, values } => {
+                                if values["ID"].starts_with(&tag[..(tag.len() - 1)]) {
+                                    Some(values["ID"].clone())
                                 } else {
                                     None
                                 }
@@ -111,6 +111,7 @@ pub(crate) fn make_table_report(
                             _ => None,
                         })
                         .collect::<Vec<String>>();
+                    dbg!(&prefix_tags);
                     for prefix_tag in prefix_tags {
                         read_bcf_record(&mut info_map, &mut variant, &header, &prefix_tag)?;
                     }

--- a/src/bcf/report/table_report/create_report_table.rs
+++ b/src/bcf/report/table_report/create_report_table.rs
@@ -103,7 +103,7 @@ pub(crate) fn make_table_report(
                         .filter_map(|header_record| match header_record {
                             HeaderRecord::Info { key: _, values } => {
                                 if values["ID"].starts_with(&tag[..(tag.len() - 1)]) {
-                                    Some(values["ID"].clone())
+                                    Some(values["ID"].to_owned())
                                 } else {
                                     None
                                 }
@@ -111,7 +111,6 @@ pub(crate) fn make_table_report(
                             _ => None,
                         })
                         .collect::<Vec<String>>();
-                    dbg!(&prefix_tags);
                     for prefix_tag in prefix_tags {
                         read_bcf_record(&mut info_map, &mut variant, &header, &prefix_tag)?;
                     }

--- a/src/bcf/report/table_report/create_report_table.rs
+++ b/src/bcf/report/table_report/create_report_table.rs
@@ -112,10 +112,10 @@ pub(crate) fn make_table_report(
                         })
                         .collect::<Vec<String>>();
                     for prefix_tag in prefix_tags {
-                        read_bcf_record(&mut info_map, &mut variant, &header, &prefix_tag)?;
+                        read_tag_entries(&mut info_map, &mut variant, &header, &prefix_tag)?;
                     }
                 } else {
-                    read_bcf_record(&mut info_map, &mut variant, &header, &tag)?;
+                    read_tag_entries(&mut info_map, &mut variant, &header, &tag)?;
                 }
             }
             Some(serde_json::to_string(&json!(info_map))?)
@@ -403,7 +403,7 @@ pub(crate) fn get_ann_description(header_records: Vec<HeaderRecord>) -> Option<V
     None
 }
 
-fn read_bcf_record(
+fn read_tag_entries(
     info_map: &mut HashMap<String, Vec<Value>>,
     variant: &mut Record,
     header: &HeaderView,

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -251,7 +251,7 @@ subcommands:
             long: info
             short: i
             value_name: INFO_TAG
-            help: Add custom values from the info field to each variant into the table report.
+            help: Add custom values from the info field to each variant into the table report. Multiple fields starting with the same prefix can be added by placing '*' at the and of a prefix.
         - format:
             multiple: true
             required: false


### PR DESCRIPTION
As the title says it is now possible to define prefixes for INFO-field records by adding a `*` at the end of a record string.