### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.1.0
+    hooks:
+      - id: check-byte-order-marker
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: master
+    hooks:
+      - id: fmt
+      - id: cargo-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v3.3.0
     hooks:
       - id: check-byte-order-marker
       - id: check-case-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,4 +14,5 @@ repos:
     rev: master
     hooks:
       - id: fmt
+      - id: clippy
       - id: cargo-check

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Rust-Bio-Tools provides a command `rbt`, which currently supports the following 
 * a tool to merge BAM or FASTQ reads using marked duplicates respectively unique molecular identifiers (UMIs) (`rbt collapse-reads-to-fragments bam|fastq`)
 * a tool to generate interactive HTML based reports that offer multiple plots visualizing the provided genomics data in VCF and BAM format (`rbt vcf-report`)
 
-Further functionality is added as it is needed by the authors. Any contributions are highly welcome.
+Further functionality is added as it is needed by the authors. Check out the [Contributing](#Contributing) section if you want contribute anything yourself.
 For a list of changes, take a look at the [CHANGELOG](CHANGELOG.md).
 
 
@@ -46,10 +46,16 @@ Rust-Bio-Tools installs a command line utility `rbt`. Issue
 
 for a summary of all options and tools.
 
+## Contributing
+
+Any contributions are highly welcome. If you plan to contribute we suggest installing pre-commit hooks. To do so:
+1. Install `pre-commit` as explained [here](https://pre-commit.com/#installation)
+2. Run `pre-commit install` in the rust-bio-tools base directory
+
+This should format, check and lint your code when committing.
 
 ## Authors
 
 * Johannes Köster (https://koesterlab.github.io)
 * Felix Mölder
 * Henning Timm
-


### PR DESCRIPTION
Just as https://github.com/rust-bio/rust-bio/pull/312, but also including `cargo clippy`. Usage explained by @tedil: 

> In order to reduce the number of "fmt" commits (and hence reduce the number of CI triggers), this PR adds a `.pre-commit-config.yaml` for use with [pre-commit](https://pre-commit.com/).
> In order to use this:
> 
> 1. install `pre-commit` (see [pre-commit.com/#installation)](https://pre-commit.com/#installation)
> 2. run `pre-commit install` in the rust-bio base dir
> 
> and henceforth every time you commit, _changes_ will be formatted with rustftm and checked with cargo check!

@johanneskoester I'd be happy adding a short explanation just as above to our README.md or anywhere else you'd think it'd fit appropriately.
