### PR TITLE
Fix problems with latest cc version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ lazy_static = "1.4"
 anyhow = "1"
 thiserror = "1"
 
+# TODO: Fix https://github.com/rust-rocksdb/rust-rocksdb/issues/479
 [build-dependencies.cc]
 version = "=1.0.61"
 features = ["parallel"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,10 @@ lazy_static = "1.4"
 anyhow = "1"
 thiserror = "1"
 
+[build-dependencies.cc]
+version = "=1.0.61"
+features = ["parallel"]
+
 [[bin]]
 name = "rbt"
 path = "src/main.rs"


### PR DESCRIPTION
This PR temporarily fixes a [problem](https://github.com/rust-rocksdb/rust-rocksdb/issues/479) with the latest `v1.0.63` of `cc` that stops `rust-rocksdb` from compiling by simply using an older version of `cc`. 