### PR TITLE
Remove workaround for cc version v1.0.63

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,11 +47,6 @@ lazy_static = "1.4"
 anyhow = "1"
 thiserror = "1"
 
-# TODO: Fix https://github.com/rust-rocksdb/rust-rocksdb/issues/479
-[build-dependencies.cc]
-version = "=1.0.61"
-features = ["parallel"]
-
 [[bin]]
 name = "rbt"
 path = "src/main.rs"


### PR DESCRIPTION
This PR removes the explicit `cc` version from the `Cargo.toml` now that https://github.com/rust-rocksdb/rust-rocksdb/issues/479 is fixed with the release of `v1.0.65`.