### PR TITLE
Parallelise `table_report` calls over samples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ chrono = "0.4"
 lazy_static = "1.4"
 anyhow = "1"
 thiserror = "1"
+rayon = "1.5"
 
 [[bin]]
 name = "rbt"


### PR DESCRIPTION
When you have lots of samples, it takes quite some time to build all the individual table reports sequentially; this can be parallelised easily with rayon.