### PR TITLE
Add threads parameter to vcf-report

### DIFF
--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -278,6 +278,11 @@ subcommands:
             long: tsv
             value_name: TSV_FILE_PATH
             help: Add a TSV file that contains one or multiple custom values for each sample for the oncoprint. First column has to be the sample name, followed by one or more columns with custom values. Make sure you include one row for each given sample.
+        - threads:
+            long: threads
+            required: false
+            default_value: "8"
+            help: Sets the number of threads used to build the table reports.
         - output-path:
             last: true
             required: false

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -281,7 +281,7 @@ subcommands:
         - threads:
             long: threads
             required: false
-            default_value: "8"
+            default_value: "0"
             help: Sets the number of threads used to build the table reports.
         - output-path:
             last: true

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,8 +136,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             }
             let pool = rayon::ThreadPoolBuilder::new()
                 .num_threads(threads)
-                .build()
-                .unwrap();
+                .build()?;
             pool.install(|| {
                 sample_calls.par_iter().for_each(|(sample, sample_call)| {
                     bcf::report::table_report::table_report(


### PR DESCRIPTION
As requested by @johanneskoester in #98 this PR adds a `--threads` parameter to the vcf-report. As i haven't got much experience with [rayon](https://github.com/rayon-rs/rayon) it'd be great to know if i used it in the right way. 