### PR TITLE
Allow VCF files without CLIN_SIG

### DIFF
--- a/src/bcf/report/oncoprint.rs
+++ b/src/bcf/report/oncoprint.rs
@@ -50,6 +50,7 @@ pub fn oncoprint(
         None
     };
 
+    // Check every VCF file for presence of CLIN_SIG
     let mut clin_sig_present = HashMap::new();
     for (sample, path) in sample_calls.iter().sorted() {
         let bcf_reader = bcf::Reader::from_path(path)?;
@@ -63,6 +64,7 @@ pub fn oncoprint(
         );
     }
 
+    // Check wether any of the VCF files contain CLIN_SIG at all
     let cs_present_folded = clin_sig_present.iter().fold(false, |b, (_, c)| b || *c);
 
     for (sample, path) in sample_calls.iter().sorted() {


### PR DESCRIPTION
This PR allows the usage of VCF files without the need of `CLIN_SIG` to be present in each file. In case it is not present in any of the files the plot is completely omitted. This also adds a proper error message in case the `ANN` field is not present at all.