### PR TITLE
Remove git dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ anyhow = "1"
 thiserror = "1"
 rayon = "1.5"
 structopt = "0.3"
-lz-string = { git = "https://github.com/adumbidiot/lz-string-rs.git" }
+lz-str = "0.1.0"
 
 [[bin]]
 name = "rbt"

--- a/src/bcf/report/table_report/create_report_table.rs
+++ b/src/bcf/report/table_report/create_report_table.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Local};
 use itertools::Itertools;
 use jsonm::packer::{PackOptions, Packer};
 use log::warn;
-use lz_string::compress_to_utf16;
+use lz_str::compress_to_utf16;
 use rust_htslib::bcf::header::{HeaderView, TagType};
 use rust_htslib::bcf::{HeaderRecord, Read, Record};
 use rustc_serialize::json::Json;


### PR DESCRIPTION
Just a quick removal of the git dependency now that [lz-str](https://crates.io/crates/lz-str) got released to crates.io.