### PR TITLE
Add new parameter for additional bar plots

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-bio-tools"
-version = "0.17.0"
+version = "0.17.1-alpha.0"
 authors = ["Johannes Köster <johannes.koester@tu-dortmund.de>", "Erik Clarke <ecl@pennmedicine.upenn.edu>"]
 description = "A set of fast and robust command line utilities for bioinformatics tasks based on Rust-Bio."
 license-file = "LICENSE.md"

--- a/src/bcf/report/highlight_specs.json
+++ b/src/bcf/report/highlight_specs.json
@@ -1,0 +1,8 @@
+{
+  "type":"single",
+  "empty":"none",
+  "on":"mouseover",
+  "fields":[
+    "key"
+  ]
+}

--- a/src/bcf/report/info_specs.json
+++ b/src/bcf/report/info_specs.json
@@ -1,0 +1,41 @@
+{
+  "data":{
+    "name":""
+  },
+  "mark":"bar",
+  "width":100,
+  "selection":{
+  },
+  "encoding":{
+    "y":{
+      "field":"key",
+      "type":"ordinal",
+      "sort": {},
+      "axis": null
+    },
+    "x":{
+      "field":"count",
+      "aggregate":"sum",
+      "stack":  "normalize",
+      "type":"quantitative",
+      "axis":{
+        "title":""
+      }
+    },
+    "fillOpacity":{
+      "condition":{
+        "selection":"",
+        "value":0.5
+      },
+      "value":1
+    },
+    "color":{
+      "field":"value",
+      "type":"nominal",
+      "title":"existing variations",
+      "scale":{
+        "type":"ordinal"
+      }
+    }
+  }
+}

--- a/src/bcf/report/oncoprint.rs
+++ b/src/bcf/report/oncoprint.rs
@@ -12,6 +12,7 @@ use serde_derive::Serialize;
 use tera::{self, Context, Tera};
 
 use crate::bcf::report::table_report::create_report_table::get_ann_description;
+use crate::bcf::report::table_report::create_report_table::read_tag_entries;
 use chrono::{DateTime, Local};
 use jsonm::packer::{PackOptions, Packer};
 use rust_htslib::bcf::{self, Read};
@@ -29,6 +30,7 @@ pub fn oncoprint(
     output_path: &str,
     max_cells: u32,
     tsv_data_path: Option<&str>,
+    plot_info: Option<Vec<String>>,
 ) -> Result<(), Box<dyn Error>> {
     let mut data = HashMap::new();
     let mut gene_data = HashMap::new();
@@ -43,6 +45,8 @@ pub fn oncoprint(
     let mut af_data = Vec::new();
     let mut gene_af_data = HashMap::new();
     let mut unique_genes = HashMap::new();
+    let mut plot_info_data = HashMap::new();
+    let mut gene_plot_info_data = HashMap::new();
 
     let tsv_data = if let Some(tsv) = tsv_data_path {
         Some(make_tsv_records(tsv.to_owned())?)
@@ -78,6 +82,9 @@ pub fn oncoprint(
         let mut clin_sigs = HashMap::new();
         let mut gene_clin_sigs = HashMap::new();
         let mut ann_indices = HashMap::new();
+        let mut pi_data = HashMap::new();
+        let mut gene_pi_data = HashMap::new();
+
         let mut bcf_reader = bcf::Reader::from_path(path)?;
         let header = bcf_reader.header().clone();
         let mut sample_names = Vec::new();
@@ -97,7 +104,7 @@ pub fn oncoprint(
 
         for res in bcf_reader.records() {
             let mut gene_data_per_record = HashMap::new();
-            let record = res?;
+            let mut record = res?;
             let alleles = record
                 .alleles()
                 .into_iter()
@@ -107,6 +114,14 @@ pub fn oncoprint(
             let ref_allele = alleles[0].to_owned();
             let dup = [ref_allele.clone(), ref_allele.clone()].concat();
             let rev = ref_allele.clone().into_iter().rev().collect_vec();
+
+            let mut info_map = HashMap::new();
+            if plot_info.is_some() {
+                for tag in &plot_info.clone().unwrap() {
+                    read_tag_entries(&mut info_map, &mut record, &header, tag)?;
+                }
+            }
+            dbg!(&info_map);
 
             let allel_frequencies = record
                 .format(b"AF")
@@ -214,6 +229,52 @@ pub fn oncoprint(
                             protein_alteration
                         };
 
+                        if plot_info.is_some() {
+                            for key in plot_info.clone().unwrap() {
+                                let info = info_map.get(&key.clone());
+                                if info.is_none() {
+                                    let e = pi_data.entry(key.clone()).or_insert_with(HashMap::new);
+                                    let rec = e.entry(gene.to_owned()).or_insert_with(Vec::new);
+                                    rec.push(BarPlotRecord::new(
+                                        gene.to_owned(),
+                                        "unknown".to_string(),
+                                    ));
+                                    let e2 = gene_pi_data
+                                        .entry(key.clone())
+                                        .or_insert_with(HashMap::new);
+                                    let rec2 = e2.entry(gene.to_owned()).or_insert_with(Vec::new);
+                                    rec2.push(BarPlotRecord::new(
+                                        alt.to_owned(),
+                                        "unknown".to_string(),
+                                    ));
+                                } else {
+                                    for val in info.unwrap() {
+                                        let value = if val == &json!("") || val == &json!(".") {
+                                            "unknown".to_string()
+                                        } else {
+                                            val.to_string()
+                                        };
+                                        let e =
+                                            pi_data.entry(key.clone()).or_insert_with(HashMap::new);
+                                        let rec = e.entry(gene.to_owned()).or_insert_with(Vec::new);
+                                        rec.push(BarPlotRecord::new(
+                                            gene.to_owned(),
+                                            value.clone(),
+                                        ));
+                                        let e2 = gene_pi_data
+                                            .entry(key.clone())
+                                            .or_insert_with(HashMap::new);
+                                        let rec2 =
+                                            e2.entry(gene.to_owned()).or_insert_with(Vec::new);
+                                        rec2.push(BarPlotRecord::new(
+                                            alt.to_owned(),
+                                            value.clone(),
+                                        ));
+                                    }
+                                }
+                            }
+                        }
+
                         let split_ev = existing_var.split('&').collect_vec();
                         for ex_var in split_ev {
                             let mut ev: String =
@@ -317,6 +378,14 @@ pub fn oncoprint(
             let final_evs = make_final_bar_plot_records(ex_var);
             existing_var_data.push(final_evs);
 
+            for (tag, map) in pi_data.clone() {
+                if let Some(t_data) = map.get(gene) {
+                    let final_data = make_final_bar_plot_records(t_data);
+                    let e = plot_info_data.entry(tag).or_insert_with(Vec::new);
+                    e.push(final_data);
+                }
+            }
+
             let consequence = consequences.get(gene).unwrap();
             let final_consequences = make_final_bar_plot_records(consequence);
             consequence_data.push(final_consequences);
@@ -333,6 +402,15 @@ pub fn oncoprint(
                 .entry(gene.to_owned())
                 .or_insert_with(Vec::new);
             e.push(final_gene_impacts);
+
+            for (tag, map) in gene_pi_data.clone() {
+                if let Some(t_data) = map.get(gene) {
+                    let final_data = make_final_bar_plot_records(t_data);
+                    let m = gene_plot_info_data.entry(tag).or_insert_with(HashMap::new);
+                    let e = m.entry(gene.to_owned()).or_insert_with(Vec::new);
+                    e.push(final_data);
+                }
+            }
 
             let gene_evs = gene_existing_variations.get(gene).unwrap();
             let final_gene_evs = make_final_bar_plot_records(gene_evs);
@@ -393,6 +471,13 @@ pub fn oncoprint(
         let final_impact: Vec<_> = impact_data.iter().flatten().sorted().collect();
         let existing_var_data = gene_existing_var_data.get(&gene).unwrap();
         let final_ev: Vec<_> = existing_var_data.iter().flatten().sorted().collect();
+        let mut inf_plot_data = HashMap::new();
+        for (tag, data) in &gene_plot_info_data {
+            if let Some(d) = data.get(&gene) {
+                let final_data: Vec<_> = d.iter().flatten().sorted().collect();
+                inf_plot_data.insert(tag.to_owned(), final_data.clone());
+            }
+        }
         let consequence_data = gene_consequence_data.get(&gene).unwrap();
         let final_consequence: Vec<_> = consequence_data.iter().flatten().sorted().collect();
         let clin_sig_data = gene_clin_sig_data.get(&gene).unwrap();
@@ -473,6 +558,18 @@ pub fn oncoprint(
                     .filter(|entry| sorted_alterations.contains(&&&entry.key))
                     .collect();
 
+                let mut info_page_data = HashMap::new();
+                if plot_info.is_some() {
+                    for (tag, data) in inf_plot_data.clone() {
+                        info_page_data.insert(
+                            tag,
+                            data.into_iter()
+                                .filter(|entry| sorted_alterations.contains(&&&entry.record.key))
+                                .collect_vec(),
+                        );
+                    }
+                }
+
                 let order: Vec<_> = ordered_alts
                     .iter()
                     .filter(|gene| sorted_alterations.contains(gene))
@@ -487,15 +584,43 @@ pub fn oncoprint(
                     json!({ "main": page_data, "impact": impact_page_data, "ev": ev_page_data, "consequence": consequence_page_data, "allel_frequency": af_page_data})
                 };
 
+                if plot_info.is_some() {
+                    for (tag, data) in info_page_data {
+                        values[tag] = json!(data);
+                    }
+                }
+
                 if let Some(ref tsv) = tsv_data {
                     for (title, data) in tsv {
                         values[title] = json!(data);
                     }
                 }
+
                 specs["datasets"] = values;
                 if !cs_present_folded {
                     let hconcat = specs["vconcat"][1]["hconcat"].as_array_mut().unwrap();
                     hconcat.remove(4);
+                    specs["vconcat"][1]["hconcat"] = json!(hconcat);
+                }
+
+                if plot_info.is_some() {
+                    let info_specs: Value =
+                        serde_json::from_str(include_str!("info_specs.json")).unwrap();
+                    let highlight_specs: Value =
+                        serde_json::from_str(include_str!("highlight_specs.json")).unwrap();
+                    let hconcat = specs["vconcat"][1]["hconcat"].as_array_mut().unwrap();
+                    for (tag, _) in &plot_info_data {
+                        let mut tag_specs = info_specs.clone();
+                        tag_specs["data"] = json!({ "name": tag });
+                        let highlight_name = "highlight_".to_string() + tag;
+                        tag_specs["selection"] = json!({ &highlight_name: highlight_specs });
+                        tag_specs["encoding"]["color"]["title"] = json!(tag);
+                        tag_specs["encoding"]["x"]["title"] = json!(tag);
+                        tag_specs["encoding"]["fillOpacity"]["condition"]["selection"] =
+                            json!(highlight_name);
+                        hconcat.push(tag_specs);
+                    }
+
                     specs["vconcat"][1]["hconcat"] = json!(hconcat);
                 }
 
@@ -554,6 +679,12 @@ pub fn oncoprint(
     let ev_data: Vec<_> = existing_var_data.iter().flatten().collect();
     let consequence_data: Vec<_> = consequence_data.iter().flatten().collect();
     let clin_sig_data: Vec<_> = clin_sig_data.iter().flatten().collect();
+    let mut i_plot_data = HashMap::new();
+    if plot_info.is_some() {
+        for (tag, data) in plot_info_data.clone() {
+            i_plot_data.insert(tag, data.into_iter().flatten().collect_vec());
+        }
+    }
 
     let sorted_impacts = order_by_impact(impact_data.clone());
     let sorted_clin_sigs = order_by_clin_sig(clin_sig_data.clone());
@@ -682,6 +813,18 @@ pub fn oncoprint(
                 .filter(|entry| sorted_genes.contains(&&entry.key))
                 .collect();
 
+            let mut info_page_data = HashMap::new();
+            if plot_info.is_some() {
+                for (tag, data) in i_plot_data.clone() {
+                    info_page_data.insert(
+                        tag,
+                        data.into_iter()
+                            .filter(|entry| sorted_genes.contains(&&entry.record.key))
+                            .collect_vec(),
+                    );
+                }
+            }
+
             let order: Vec<_> = ordered_genes
                 .iter()
                 .filter(|gene| sorted_genes.contains(gene))
@@ -699,6 +842,12 @@ pub fn oncoprint(
                 json!({ "main": page_data, "impact": impact_page_data, "ev": ev_page_data, "consequence": consequence_page_data, "allel_frequency": af_page_data})
             };
 
+            if plot_info.is_some() {
+                for (tag, data) in info_page_data {
+                    values[tag] = json!(data);
+                }
+            }
+
             if let Some(ref tsv) = tsv_data {
                 for (title, data) in tsv {
                     values[title] = json!(data);
@@ -709,6 +858,27 @@ pub fn oncoprint(
             if !cs_present_folded {
                 let hconcat = vl_specs["vconcat"][1]["hconcat"].as_array_mut().unwrap();
                 hconcat.remove(4);
+                vl_specs["vconcat"][1]["hconcat"] = json!(hconcat);
+            }
+
+            if plot_info.is_some() {
+                let info_specs: Value =
+                    serde_json::from_str(include_str!("info_specs.json")).unwrap();
+                let highlight_specs: Value =
+                    serde_json::from_str(include_str!("highlight_specs.json")).unwrap();
+                let hconcat = vl_specs["vconcat"][1]["hconcat"].as_array_mut().unwrap();
+                for (tag, _) in &plot_info_data {
+                    let mut tag_specs = info_specs.clone();
+                    tag_specs["data"] = json!({ "name": tag });
+                    let highlight_name = "highlight_".to_string() + tag;
+                    tag_specs["selection"] = json!({ &highlight_name: highlight_specs });
+                    tag_specs["encoding"]["color"]["title"] = json!(tag);
+                    tag_specs["encoding"]["x"]["title"] = json!(tag);
+                    tag_specs["encoding"]["fillOpacity"]["condition"]["selection"] =
+                        json!(highlight_name);
+                    hconcat.push(tag_specs);
+                }
+
                 vl_specs["vconcat"][1]["hconcat"] = json!(hconcat);
             }
 

--- a/src/bcf/report/oncoprint.rs
+++ b/src/bcf/report/oncoprint.rs
@@ -608,7 +608,7 @@ pub fn oncoprint(
                     let highlight_specs: Value =
                         serde_json::from_str(include_str!("highlight_specs.json")).unwrap();
                     let hconcat = specs["vconcat"][1]["hconcat"].as_array_mut().unwrap();
-                    for (tag, _) in &plot_info_data {
+                    for tag in plot_info_data.keys() {
                         let mut tag_specs = info_specs.clone();
                         tag_specs["data"] = json!({ "name": tag });
                         let highlight_name = "highlight_".to_string() + tag;
@@ -866,7 +866,7 @@ pub fn oncoprint(
                 let highlight_specs: Value =
                     serde_json::from_str(include_str!("highlight_specs.json")).unwrap();
                 let hconcat = vl_specs["vconcat"][1]["hconcat"].as_array_mut().unwrap();
-                for (tag, _) in &plot_info_data {
+                for tag in plot_info_data.keys() {
                     let mut tag_specs = info_specs.clone();
                     tag_specs["data"] = json!({ "name": tag });
                     let highlight_name = "highlight_".to_string() + tag;

--- a/src/bcf/report/oncoprint.rs
+++ b/src/bcf/report/oncoprint.rs
@@ -121,7 +121,6 @@ pub fn oncoprint(
                     read_tag_entries(&mut info_map, &mut record, &header, tag)?;
                 }
             }
-            dbg!(&info_map);
 
             let allel_frequencies = record
                 .format(b"AF")

--- a/src/bcf/report/oncoprint.rs
+++ b/src/bcf/report/oncoprint.rs
@@ -251,7 +251,7 @@ pub fn oncoprint(
                                         let value = if val == &json!("") || val == &json!(".") {
                                             "unknown".to_string()
                                         } else {
-                                            val.to_string()
+                                            val.to_string().trim_matches('\"').to_owned()
                                         };
                                         let e =
                                             pi_data.entry(key.clone()).or_insert_with(HashMap::new);

--- a/src/bcf/report/table_report/create_report_table.rs
+++ b/src/bcf/report/table_report/create_report_table.rs
@@ -446,7 +446,7 @@ pub(crate) fn get_ann_description(header_records: Vec<HeaderRecord>) -> Option<V
     None
 }
 
-fn read_tag_entries(
+pub(crate) fn read_tag_entries(
     info_map: &mut HashMap<String, Vec<Value>>,
     variant: &mut Record,
     header: &HeaderView,
@@ -455,25 +455,28 @@ fn read_tag_entries(
     let (tag_type, _) = header.info_type(tag.as_bytes())?;
     match tag_type {
         TagType::String => {
-            let values = variant.info(tag.as_bytes()).string()?.unwrap();
-            for v in values.iter() {
-                let value = String::from_utf8(Vec::from(v.to_owned()))?;
-                let entry = info_map.entry(tag.to_owned()).or_insert_with(Vec::new);
-                entry.push(json!(value));
+            if let Some(values) = variant.info(tag.as_bytes()).string()? {
+                for v in values.iter() {
+                    let value = String::from_utf8(Vec::from(v.to_owned()))?;
+                    let entry = info_map.entry(tag.to_owned()).or_insert_with(Vec::new);
+                    entry.push(json!(value));
+                }
             }
         }
         TagType::Float => {
-            let values = variant.info(tag.as_bytes()).float()?.unwrap();
-            for v in values.iter() {
-                let entry = info_map.entry(tag.to_owned()).or_insert_with(Vec::new);
-                entry.push(json!(v));
+            if let Some(values) = variant.info(tag.as_bytes()).float()? {
+                for v in values.iter() {
+                    let entry = info_map.entry(tag.to_owned()).or_insert_with(Vec::new);
+                    entry.push(json!(v));
+                }
             }
         }
         TagType::Integer => {
-            let values = variant.info(tag.as_bytes()).integer()?.unwrap();
-            for v in values.iter() {
-                let entry = info_map.entry(tag.to_owned()).or_insert_with(Vec::new);
-                entry.push(json!(v));
+            if let Some(values) = variant.info(tag.as_bytes()).integer()? {
+                for v in values.iter() {
+                    let entry = info_map.entry(tag.to_owned()).or_insert_with(Vec::new);
+                    entry.push(json!(v));
+                }
             }
         }
         _ => {}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -218,6 +218,10 @@ pub(crate) enum Command {
         #[structopt(long, short = "f", value_name = "FORMAT_TAG")]
         formats: Option<Vec<String>>,
 
+        /// Add multiple keys from the info field of your vcf to the plots of the first and second stage of the report.
+        #[structopt(long, value_name = "PLOT_INFO")]
+        plot_info: Option<Vec<String>>,
+
         /// Change the default javascript file for the table-report to a custom one to add own plots or tables to the sidebar by appending these to an empty div in the HTML template.
         #[structopt(long, short = "j", value_name = "JS_FILE_PATH")]
         custom_js_template: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             max_read_depth,
             infos,
             formats,
+            plot_info,
             custom_js_template,
             custom_js_files,
             tsv,
@@ -162,7 +163,13 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .unwrap_or_else(|_| panic!("Failed building table report for sample {}", sample));
             });
 
-            bcf::report::oncoprint::oncoprint(&sample_calls, &output_path, cells, tsv.as_deref())?
+            bcf::report::oncoprint::oncoprint(
+                &sample_calls,
+                &output_path,
+                cells,
+                tsv.as_deref(),
+                plot_info,
+            )?
         }
         VcfSplit { input, output } => bcf::split::split(input, output.as_ref())?,
         CollapseReadsToFragments { cmd } => match cmd {


### PR DESCRIPTION
This PR adds a new parameter `--plot-info`, that takes info keys of a vcf or bcf file that will be then added to the first and second stage of the report in form of a bar plot.