### PR TITLE
Allow no symbol or gene field

### DIFF
--- a/src/bcf/report/js/report.js
+++ b/src/bcf/report/js/report.js
@@ -52,7 +52,11 @@ vegaEmbed('#oncoprint', spec).then(function(result) {
     result.view.addEventListener('click', function(event, item) {
         if (item.datum.gene !== undefined || item.datum.key !== undefined) {
             if (item.datum.gene !== undefined ) {
-                window.location.href = '../genes/' + item.datum.gene + '1.html';
+                if (item.datum.gene.startsWith("ENST") && item.datum.sample !== undefined) {
+                    window.location.href = '../details/' + item.datum.sample + '/' + item.datum.gene + '.html';
+                } else {
+                    window.location.href = '../genes/' + item.datum.gene + '1.html';
+                }
             } else {
                 window.location.href = '../genes/' + item.datum.key + '1.html';
             }
@@ -61,7 +65,7 @@ vegaEmbed('#oncoprint', spec).then(function(result) {
     });
 });
 
-window.addEventListener('resize', function(event){
+window.addEventListener('resize', function(event) {
     let page_width =  $(window).width();
     let matrix_width = Math.min(page_width - 740, samples*20);
     if (matrix_width < 20 && samples >= 2) {
@@ -84,7 +88,11 @@ window.addEventListener('resize', function(event){
         result.view.addEventListener('click', function(event, item) {
             if (item.datum.gene !== undefined || item.datum.key !== undefined) {
                 if (item.datum.gene !== undefined ) {
-                    window.location.href = '../genes/' + item.datum.gene + '1.html';
+                    if (item.datum.gene.startsWith("ENST") && item.datum.sample !== undefined) {
+                        window.location.href = '../details/' + item.datum.sample + '/' + item.datum.gene + '.html';
+                    } else {
+                        window.location.href = '../genes/' + item.datum.gene + '1.html';
+                    }
                 } else {
                     window.location.href = '../genes/' + item.datum.key + '1.html';
                 }

--- a/src/bcf/report/oncoprint.rs
+++ b/src/bcf/report/oncoprint.rs
@@ -159,8 +159,11 @@ pub fn oncoprint(
                             get_field("SYMBOL")?
                         } else if !get_field("Gene")?.is_empty() {
                             get_field("Gene")?
+                        } else if !get_field("HGVSg")?.is_empty() {
+                            warn!("Warning! Found allele in {:?} without SYMBOL or Gene field. Using HGVSg instead.", record);
+                            get_field("HGVSg")?
                         } else {
-                            warn!("Warning! Found allele in {:?} without SYMBOL or Gene field. This record will be skipped!", record);
+                            warn!("Warning! Found allele in {:?} without SYMBOL, Gene or HGVSg field. This record will be skipped!", record);
                             continue;
                         };
                         let dna_alteration = get_field("HGVSg")?;

--- a/src/bcf/report/table_report/create_report_table.rs
+++ b/src/bcf/report/table_report/create_report_table.rs
@@ -79,6 +79,9 @@ pub(crate) fn make_table_report(
         *ann_indices
             .get(&String::from("Gene"))
             .expect("No field named Gene found. Please only use VEP-annotated VCF-files."),
+        *ann_indices
+            .get(&String::from("HGVSg"))
+            .expect("No field named HGVSg found. Please only use VEP-annotated VCF-files."),
     )?;
 
     for (record_index, v) in vcf.records().enumerate() {
@@ -209,8 +212,11 @@ pub(crate) fn make_table_report(
                     get_field("SYMBOL")?
                 } else if !get_field("Gene")?.is_empty() {
                     get_field("Gene")?
+                } else if !get_field("HGVSg")?.is_empty() {
+                    warn!("Warning! Found allele in {:?} without SYMBOL or Gene field. Using HGVSg instead.", variant);
+                    get_field("HGVSg")?
                 } else {
-                    warn!("Warning! Found allele in {:?} without SYMBOL or Gene field. This record will be skipped!", variant);
+                    warn!("Warning! Found allele in {:?} without SYMBOL, Gene or HGVSg field. This record will be skipped!", variant);
                     continue;
                 };
                 genes.push(gene.to_owned());
@@ -563,6 +569,7 @@ fn get_gene_ending(
     vcf_path: &Path,
     symbol_index: usize,
     gene_index: usize,
+    hgvsg_index: usize,
 ) -> Result<HashMap<String, u32>, Box<dyn Error>> {
     let mut endings = HashMap::new();
     let mut vcf = rust_htslib::bcf::Reader::from_path(&vcf_path).unwrap();
@@ -574,6 +581,9 @@ fn get_gene_ending(
                 let mut gene = std::str::from_utf8(fields[symbol_index])?;
                 if gene.is_empty() {
                     gene = std::str::from_utf8(fields[gene_index])?;
+                }
+                if gene.is_empty() {
+                    gene = std::str::from_utf8(fields[hgvsg_index])?;
                 }
                 endings.insert(gene.to_owned(), record_index as u32);
             }


### PR DESCRIPTION
This PR allows records without `SYMBOL` or `Gene` fields present. Instead `HGVSg` will be used. Note that `HGVSg` **must** be present in order for the record to appear in the report. Records with displayed with `HGVSg` in the first stage of the report will directly link to the detail view of the report (only when a sample is selected by using the main matrix for navigation).