### PR TITLE
Improve warning for missing fields

### DIFF
--- a/src/bcf/report/oncoprint.rs
+++ b/src/bcf/report/oncoprint.rs
@@ -6,7 +6,6 @@ use std::{fs, str};
 use derive_new::new;
 use itertools::Itertools;
 use lazy_static::lazy_static;
-use log::warn;
 use regex::Regex;
 use serde_derive::Serialize;
 use tera::{self, Context, Tera};
@@ -174,10 +173,8 @@ pub fn oncoprint(
                         } else if !get_field("Gene")?.is_empty() {
                             get_field("Gene")?
                         } else if !get_field("HGVSg")?.is_empty() {
-                            warn!("Warning! Found allele in {:?} without SYMBOL or Gene field. Using HGVSg instead.", record);
                             get_field("HGVSg")?
                         } else {
-                            warn!("Warning! Found allele in {:?} without SYMBOL, Gene or HGVSg field. This record will be skipped!", record);
                             continue;
                         };
                         let dna_alteration = get_field("HGVSg")?;

--- a/src/bcf/report/table_report/create_report_table.rs
+++ b/src/bcf/report/table_report/create_report_table.rs
@@ -213,10 +213,10 @@ pub(crate) fn make_table_report(
                 } else if !get_field("Gene")?.is_empty() {
                     get_field("Gene")?
                 } else if !get_field("HGVSg")?.is_empty() {
-                    warn!("Warning! Found allele in {:?} without SYMBOL or Gene field. Using HGVSg instead.", variant);
+                    warn!("Warning! Found allele without SYMBOL or Gene field in record at {}:{}. Using HGVSg instead.", &chrom, variant.pos());
                     get_field("HGVSg")?
                 } else {
-                    warn!("Warning! Found allele in {:?} without SYMBOL, Gene or HGVSg field. This record will be skipped!", variant);
+                    warn!("Warning! Found allele without SYMBOL, Gene or HGVSg field in record at {}:{}. This record will be skipped!",  &chrom, variant.pos());
                     continue;
                 };
                 genes.push(gene.to_owned());


### PR DESCRIPTION
Just a quick improvement for a warning that now contains `chrom:pos` for the affected record, not the inner struct. 