### PR TITLE
Change import order for additional js files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.19.1] - 2021-02-08
+### Changed
+- Fix for javascript import order problem in `rbt vcf-report`.
+
 ## [0.19.0] - 2021-02-05
 ### Added
 - New subcommand csv-report that allows to generate an interactive HTML report from a CSV/TSV table.
@@ -21,18 +25,18 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - `rbt collapse-reads-to-fragments` now always writes FASTQ files since consensus reads need to be remapped anyways (MAPQ might change).
 - `rbt vcf-report` can now be parallelized.
-- various fixes and improvements for `rbt vcf-report`
-- various fixes for `rbt collapse-reads-to-fragments`
+- Various fixes and improvements for `rbt vcf-report`
+- Various fixes for `rbt collapse-reads-to-fragments`
 
 ## [0.16.0] - 2020-11-17
 ### Changed
 - `rbt collapse-reads-to-fragments bam` writes skipped reads to separate bam file now
 - `rbt collapse-reads-to-fragments bam` does not perform starcode clustering anymore
-- Fixed bug in `rbt collapse-reads-to-fragments bam` failing when read mates map to different chromosomes 
+- Fixed bug in `rbt collapse-reads-to-fragments bam` failing when read mates map to different chromosomes
 
 ## [0.15.1] - 2020-11-12
 ### Changed
-- fixed bug in vcf-split that led to unequally filled splitted VCF/BCFs.
+- Fixed bug in vcf-split that led to unequally filled splitted VCF/BCFs.
 
 ## [0.15.0] - 2020-11-11
 ### Changed
@@ -139,7 +143,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.2.0] - 2018-02-23
 ### Added
-- A tool to selectively remove records from a FASTQ file. 
+- A tool to selectively remove records from a FASTQ file.
 - A tool to calculate b-allele frequencies (BAF) from a VCF file.
 
 ## [0.1.3] - 2017-12-05

--- a/src/bcf/report/js/table-report.js
+++ b/src/bcf/report/js/table-report.js
@@ -110,5 +110,4 @@ $(document).ready(function () {
             $('#ann-sidebar').append('</tr>');
         });
     })
-    $('#variant1').trigger('click');
 })

--- a/src/bcf/report/table_report/report_table.html.tera
+++ b/src/bcf/report/table_report/report_table.html.tera
@@ -17,11 +17,11 @@
 <script src="../../js/vega-lite.min.js"></script>
 <script src="../../js/vega-embed.min.js"></script>
 <script src="../../js/lz-string.min.js"></script>
-{% for file in js_imports %}
-<script src="../../js/{{ file }}"></script>
-{% endfor %}
 <script src="plots/{{ gene }}.js"></script>
 <script src="../../js/table-report.js"></script>
+{% for file in js_imports %}
+    <script src="../../js/{{ file }}"></script>
+{% endfor %}
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <a class="navbar-brand" href="#">rbt report</a>
     <div class="collapse navbar-collapse" id="navbarText">
@@ -144,5 +144,6 @@
             </div>
         </div>
     </div>
+<script>$(document).ready(function () { $('#variant1').trigger('click');});</script>
 </body>
 </html>

--- a/tests/expected/report/details/a/KRAS.html
+++ b/tests/expected/report/details/a/KRAS.html
@@ -17,9 +17,9 @@
 <script src="../../js/vega-lite.min.js"></script>
 <script src="../../js/vega-embed.min.js"></script>
 <script src="../../js/lz-string.min.js"></script>
-
 <script src="plots/KRAS.js"></script>
 <script src="../../js/table-report.js"></script>
+
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <a class="navbar-brand" href="#">rbt report</a>
     <div class="collapse navbar-collapse" id="navbarText">
@@ -505,5 +505,6 @@
             </div>
         </div>
     </div>
+<script>$(document).ready(function () { $('#variant1').trigger('click');});</script>
 </body>
 </html>

--- a/tests/expected/report/details/b/KRAS.html
+++ b/tests/expected/report/details/b/KRAS.html
@@ -17,9 +17,9 @@
 <script src="../../js/vega-lite.min.js"></script>
 <script src="../../js/vega-embed.min.js"></script>
 <script src="../../js/lz-string.min.js"></script>
-
 <script src="plots/KRAS.js"></script>
 <script src="../../js/table-report.js"></script>
+
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <a class="navbar-brand" href="#">rbt report</a>
     <div class="collapse navbar-collapse" id="navbarText">
@@ -505,5 +505,6 @@
             </div>
         </div>
     </div>
+<script>$(document).ready(function () { $('#variant1').trigger('click');});</script>
 </body>
 </html>


### PR DESCRIPTION
This PR fixes a problem discovered by @FelixMoelder that made it impossible to add anything to the `#ann-sidebar` because it was fully cleared in the default template, which was imported (and therefore executed) after any additional js file given with `-l`. Additional js files are now imported afterwards and can add anything to the sidebar.