### PR TITLE
Improve fetching fasta sequence lengths

### DIFF
--- a/src/bcf/report/table_report/create_report_table.rs
+++ b/src/bcf/report/table_report/create_report_table.rs
@@ -1,4 +1,4 @@
-use crate::bcf::report::table_report::fasta_reader::{get_fasta_length, read_fasta};
+use crate::bcf::report::table_report::fasta_reader::{get_fasta_lengths, read_fasta};
 use crate::bcf::report::table_report::static_reader::{get_static_reads, Variant};
 use chrono::{DateTime, Local};
 use itertools::Itertools;
@@ -70,6 +70,8 @@ pub(crate) fn make_table_report(
     for (i, field) in ann_field_description.iter().enumerate() {
         ann_indices.insert(field, i);
     }
+
+    let reference_lengths = get_fasta_lengths(fasta_path);
 
     let last_gene_index = get_gene_ending(
         vcf_path,
@@ -314,7 +316,7 @@ pub(crate) fn make_table_report(
 
                 for (sample, bam) in bam_sample_path {
                     let bam_path = Path::new(bam);
-                    let fasta_length = get_fasta_length(fasta_path, &chrom)?;
+                    let fasta_length = *reference_lengths.get(&chrom).unwrap();
                     let visualization: String;
                     if pos < 75 {
                         let (content, max_rows) = create_report_data(

--- a/src/bcf/report/table_report/fasta_reader.rs
+++ b/src/bcf/report/table_report/fasta_reader.rs
@@ -1,5 +1,6 @@
 use bio::io::fasta;
 use serde::Serialize;
+use std::collections::HashMap;
 use std::path::Path;
 
 pub fn read_fasta(
@@ -37,15 +38,13 @@ pub fn read_fasta(
     fasta
 }
 
-pub fn get_fasta_length(path: &Path, chrom: &str) -> Result<u64, &'static str> {
+pub fn get_fasta_lengths(path: &Path) -> HashMap<String, u64> {
     let index = fasta::Index::with_fasta_file(&path).unwrap();
     let sequences = index.sequences();
-    for seq in sequences {
-        if seq.name == chrom {
-            return Ok(seq.len);
-        }
-    }
-    Err("No sequence found")
+    sequences
+        .iter()
+        .map(|s| (s.name.to_owned(), s.len))
+        .collect()
 }
 
 #[derive(Serialize, Clone, Debug, PartialEq)]


### PR DESCRIPTION
This PR improves the fetching of fasta sequence lengths by using a `HashMap` with contig names as keys. This avoids iterating over each sequence over and over for every plot.