### PR TITLE
Rework file naming for csv-report

### DIFF
--- a/src/csv/csv_report.html.tera
+++ b/src/csv/csv_report.html.tera
@@ -19,7 +19,7 @@
 <script src="../data/index{{ current_page }}.js"></script>
 <script src="../js/csv_report.js"></script>
 {% for title in titles %}
-<script src="../plots/{{ title }}.js"></script>
+<script src="../plots/plot_{{ loop.index0 }}.js"></script>
 {% endfor %}
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <a class="navbar-brand" href="#">rbt report</a>
@@ -64,7 +64,7 @@
                 <tr>
                     {% for title in titles %}
                     <th style="white-space: nowrap;">{{ title }}
-                        <a class="sym" data-toggle="modal" data-target="#{{ title }}" onclick="vegaEmbed('#{{ title }}_plot', {{ title }}_plot)">
+                        <a class="sym" data-toggle="modal" data-target="#{{ title }}" onclick="vegaEmbed('#plot_{{ loop.index0 }}', plot_{{ loop.index0 }})">
                             <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-bar-chart-fill" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
                                 <rect width="4" height="5" x="1" y="10" rx="1"/>
                                 <rect width="4" height="9" x="6" y="6" rx="1"/>
@@ -125,7 +125,7 @@
                     </button>
                 </div>
                 <div class="modal-body">
-                    <div id="{{ title }}_plot" style="width: 100%; height: 300px; border:none;">
+                    <div id="plot_{{ loop.index0 }}" style="width: 100%; height: 300px; border:none;">
                     </div>
                 </div>
                 <div class="modal-footer">
@@ -144,7 +144,7 @@
                     </button>
                 </div>
                 <div class="modal-body">
-                    <iframe src="../prefixes/{{ title }}.html" frameBorder="0" style="width: 100%; height: min(530px, 50vh)"></iframe>
+                    <iframe src="../prefixes/col_{{ loop.index0 }}.html" frameBorder="0" style="width: 100%; height: min(530px, 50vh)"></iframe>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>

--- a/src/csv/lookup_table.html.tera
+++ b/src/csv/lookup_table.html.tera
@@ -31,7 +31,7 @@
                 </tbody>
             </table>
         </div>
-        <div class="col-3 ml-auto" style="padding-top: 10px"><a role="button" href="../{{ title }}.html" class="btn btn-primary">Back</a></div>
+        <div class="col-3 ml-auto" style="padding-top: 10px"><a role="button" href="../col_{{ index }}.html" class="btn btn-primary">Back</a></div>
     </div>
 </div>
 </body>

--- a/src/csv/plot.js.tera
+++ b/src/csv/plot.js.tera
@@ -1,4 +1,4 @@
-let {{ title }}_plot = {
+let plot_{{ index }} = {
     "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
     "data": {"values": {{ table }}},
     "width": "container",

--- a/src/csv/prefix_table.html.tera
+++ b/src/csv/prefix_table.html.tera
@@ -23,7 +23,7 @@
                 <tbody>
                 {% for prefix, v in table %}
                 <tr>
-                    <td><a href="{{ title }}/{{ prefix }}.html" style="display: table-cell">{{ prefix }}</a></td>
+                    <td><a href="col_{{ index }}/{{ prefix }}.html" style="display: table-cell">{{ prefix }}</a></td>
                 </tr>
                 {% endfor %}
                 </tbody>

--- a/src/csv/report.rs
+++ b/src/csv/report.rs
@@ -154,7 +154,7 @@ pub(crate) fn csv_report(
         dir_path: plot_path.to_owned(),
     })?;
 
-    for title in &titles {
+    for (n, title) in titles.iter().enumerate() {
         let mut templates = Tera::default();
         templates.add_raw_template("plot.js.tera", include_str!("plot.js.tera"))?;
         let mut context = Context::new();
@@ -173,9 +173,10 @@ pub(crate) fn csv_report(
             _ => unreachable!(),
         }
         context.insert("title", &title);
+        context.insert("index", &n.to_string());
         let js = templates.render("plot.js.tera", &context)?;
 
-        let file_path = plot_path.to_owned() + title + ".js";
+        let file_path = plot_path.to_owned() + "plot_" + &n.to_string() + ".js";
         let mut file = fs::File::create(file_path)?;
         file.write_all(js.as_bytes())?;
     }
@@ -255,7 +256,7 @@ pub(crate) fn csv_report(
         dir_path: prefix_path.to_owned(),
     })?;
 
-    for title in &titles {
+    for (n, title) in titles.iter().enumerate() {
         if let Some(prefix_table) = prefixes.get(title.to_owned()) {
             let mut templates = Tera::default();
             templates.add_raw_template(
@@ -264,15 +265,16 @@ pub(crate) fn csv_report(
             )?;
             let mut context = Context::new();
             context.insert("title", title);
+            context.insert("index", &n.to_string());
             context.insert("table", prefix_table);
             context.insert("numeric", is_numeric.get(title).unwrap());
             let html = templates.render("prefix_table.html.tera", &context)?;
 
-            let file_path = output_path.to_owned() + "/prefixes/" + title + ".html";
+            let file_path = output_path.to_owned() + "/prefixes/col_" + &n.to_string() + ".html";
             let mut file = fs::File::create(file_path)?;
             file.write_all(html.as_bytes())?;
 
-            let title_path = prefix_path.to_owned() + "/" + title + "/";
+            let title_path = prefix_path.to_owned() + "/col_" + &n.to_string() + "/";
             fs::create_dir(Path::new(&title_path)).context(WriteErr::CantCreateDir {
                 dir_path: title_path.to_owned(),
             })?;
@@ -286,6 +288,7 @@ pub(crate) fn csv_report(
                 let mut context = Context::new();
                 context.insert("title", title);
                 context.insert("values", values);
+                context.insert("index", &n.to_string());
                 let html = templates.render("lookup_table.html.tera", &context)?;
 
                 let file_path = title_path.to_owned() + prefix + ".html";


### PR DESCRIPTION
This PR renews the inner file structure of the css-report, especially the naming of folders and files corresponding to the columns of the csv file, which avoids possible errors due to long titles with spaces or generally titles containing special characters