### PR TITLE
Fix vcf-report plots for multi sample files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.19.6] - 2021-03-09
+### Changed
+- Fixed a JSON syntax error in `rbt vcf-report`
+
 ## [0.19.5] - 2021-03-05
 ### Changed
 - Fixed internal file naming in order to avoid too long filenames.

--- a/src/bcf/report/table_report/plot.js.tera
+++ b/src/bcf/report/table_report/plot.js.tera
@@ -1,3 +1,3 @@
 let plots = [{
-    {% for variant in variants %}{% set last = loop.last %}{% set rowloop = loop.index %}{% for k,v in variant.vis %}{% set inner_last = loop.last %}"{{ rowloop }}_{{ loop.index }}": {{ v | safe }}{% if not inner_last %},{% endif %}{% if not last %},{% endif %}{% endfor %}{% endfor %}
+    {% for variant in variants %}{% set last = loop.last %}{% set rowloop = loop.index %}{% for k,v in variant.vis %}{% set inner_last = loop.last %}"{{ rowloop }}_{{ loop.index }}": {{ v | safe }}{% if not last %},{% endif %}{% endfor %}{% endfor %}
 }];

--- a/src/bcf/report/table_report/plot.js.tera
+++ b/src/bcf/report/table_report/plot.js.tera
@@ -1,3 +1,3 @@
 let plots = [{
-    {% for variant in variants %}{% set last = loop.last %}{% set rowloop = loop.index %}{% for k,v in variant.vis %}{% set inner_last = loop.last %}"{{ rowloop }}_{{ loop.index }}": {{ v | safe }}{% if not last %},{% endif %}{% endfor %}{% endfor %}
+    {% for variant in variants %}{% set last = loop.last %}{% set rowloop = loop.index %}{% for k,v in variant.vis %}{% set inner_last = loop.last %}"{{ rowloop }}_{{ loop.index }}": {{ v | safe }}{% if not last or not inner_last %},{% endif %}{% endfor %}{% endfor %}
 }];


### PR DESCRIPTION
This PR fixes a small syntax problem with the JSON object containing the plots for the third stage of the vcf-report. 