### PR TITLE
Remove unreasonable plots

### DIFF
--- a/src/csv/csv_report.html.tera
+++ b/src/csv/csv_report.html.tera
@@ -101,10 +101,16 @@
                         <span aria-hidden="true">&times;</span>
                     </button>
                 </div>
+                {% if is_reasonable[title] %}
                 <div class="modal-body">
                     <div id="plot_{{ loop.index0 }}" style="width: 100%; height: 300px; border:none;">
                     </div>
                 </div>
+                {% else %}
+                <div class="modal-body">
+                    <p>Too many values to plot a reasonable histogram.</p>
+                </div>
+                {% endif %}
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
                 </div>

--- a/src/csv/report.rs
+++ b/src/csv/report.rs
@@ -423,7 +423,9 @@ fn nominal_plot(table: &[HashMap<String, String>], column: String) -> Option<Vec
     let mut values = Vec::new();
     for row in table {
         let val = row.get(&column).unwrap();
-        values.push(val.to_owned());
+        if !val.is_empty() {
+            values.push(val.to_owned());
+        }
     }
     let mut count_values = HashMap::new();
     for v in values {

--- a/src/csv/report.rs
+++ b/src/csv/report.rs
@@ -420,27 +420,25 @@ fn num_plot(table: &[HashMap<String, String>], column: String) -> Vec<BinnedPlot
 }
 
 fn nominal_plot(table: &[HashMap<String, String>], column: String) -> Option<Vec<PlotRecord>> {
-    let mut values = Vec::new();
-    for row in table {
-        let val = row.get(&column).unwrap();
-        if !val.is_empty() {
-            values.push(val.to_owned());
-        }
-    }
+    let values = table
+        .iter()
+        .map(|row| row.get(&column).unwrap().to_owned())
+        .filter(|s| s.is_empty())
+        .collect_vec();
+
     let mut count_values = HashMap::new();
     for v in values {
         let entry = count_values.entry(v.to_owned()).or_insert_with(|| 0);
         *entry += 1;
     }
 
-    let mut plot_data = Vec::new();
-    for (k, v) in &count_values {
-        let plot_record = PlotRecord {
+    let mut plot_data = count_values
+        .iter()
+        .map(|(k, v)| PlotRecord {
             key: k.to_owned(),
             value: *v,
-        };
-        plot_data.push(plot_record);
-    }
+        })
+        .collect_vec();
 
     if plot_data.len() > 10 {
         let unique_values = count_values.iter().map(|(_, v)| v).collect::<HashSet<_>>();


### PR DESCRIPTION
This PR removes plots for columns with more than 10 unique nominal values that all occur equally often. Furthermore empty fields are discarded before being plotted as one occurring value.