### PR TITLE
Bugfix for nominal plots in csv-report

### DIFF
--- a/src/csv/report.rs
+++ b/src/csv/report.rs
@@ -423,7 +423,7 @@ fn nominal_plot(table: &[HashMap<String, String>], column: String) -> Option<Vec
     let values = table
         .iter()
         .map(|row| row.get(&column).unwrap().to_owned())
-        .filter(|s| s.is_empty())
+        .filter(|s| !s.is_empty())
         .collect_vec();
 
     let mut count_values = HashMap::new();


### PR DESCRIPTION
This PR fixes the filtering of empty values in nominal plots introduces in #139 by adding a missing negation to the filter statement.