### PR TITLE
Only plot reads overlaying the variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.20.6] - 2021-XX-XX
+### Changed
+- Bugfix for `rbt vcf-report` that eliminates the potential risk of receiving plots without any reads overlaying the variant when using `--max-read-depth`.
+
 ## [0.20.5] - 2021-04-19
 ### Changed
 - Bugfix for `rbt vcf-report` that stops displaying undefined values in the table-report.

--- a/src/bcf/report/table_report/create_report_table.rs
+++ b/src/bcf/report/table_report/create_report_table.rs
@@ -506,8 +506,15 @@ fn create_report_data(
         data.push(nucleobase);
     }
 
-    let (bases, matches, max_rows) =
-        get_static_reads(bam_path, fasta_path, chrom, from, to, max_read_depth)?;
+    let (bases, matches, max_rows) = get_static_reads(
+        bam_path,
+        fasta_path,
+        chrom,
+        from,
+        to,
+        max_read_depth,
+        &variant,
+    )?;
 
     for b in bases {
         let base = json!(b);


### PR DESCRIPTION
This PR makes the vcf-report only plot reads overlaying the variant. This eliminates the potential risk of receiving a plot without any reads overlaying the variant when using `--max-read-depth`. Also includes a small fix that i discovered regarding the placement of single nucleobases of reads that do not match the reference genome.