### PR TITLE
Change behaviour for multiple canonical records per gene in vcf-report

### DIFF
--- a/src/bcf/report/oncoprint.rs
+++ b/src/bcf/report/oncoprint.rs
@@ -373,12 +373,12 @@ pub fn oncoprint(
                     1 => rec.extend(filter_canonical.iter().map(|(r, _, _)| r.clone())),
                     _ => {
                         rec.extend(filter_canonical.iter().map(|(r, _, _)| r.clone()));
-                        let alterations = filter_canonical
+                        let transcripts = filter_canonical
                             .iter()
                             .map(|(r, _, _)| r.alteration.clone())
                             .collect_vec();
                         let positions = filter_canonical.iter().map(|(_, _, p)| p).collect_vec();
-                        warn!("Found more than one variant of gene {} annotated as canonical! The alterations marked as canonical are {:?} located at {:?}", &k, &alterations, &positions);
+                        warn!("Found more than one variant of gene {} annotated as canonical! The transcripts marked as canonical are {:?} located at {:?}", &k, &transcripts, &positions);
                     }
                 }
             }

--- a/src/bcf/report/oncoprint.rs
+++ b/src/bcf/report/oncoprint.rs
@@ -15,6 +15,7 @@ use anyhow::Context as AnyhowContext;
 use anyhow::Result;
 use chrono::{DateTime, Local};
 use jsonm::packer::{PackOptions, Packer};
+use log::warn;
 use lz_str::compress_to_utf16;
 use rust_htslib::bcf::{self, Read};
 use serde_json::{json, Value};
@@ -368,7 +369,10 @@ pub fn oncoprint(
                         rec.extend(record_tuples.iter().map(|(r, _)| r.clone()));
                     }
                     1 => rec.extend(filter_canonical.iter().map(|(r, _)| r.clone())),
-                    _ => panic!("Found more than one variant annotated as canonical!"),
+                    _ => {
+                        rec.extend(filter_canonical.iter().map(|(r, _)| r.clone()));
+                        warn!("Found more than one variant annotated as canonical!");
+                    }
                 }
             }
         }

--- a/src/bcf/report/oncoprint.rs
+++ b/src/bcf/report/oncoprint.rs
@@ -370,8 +370,15 @@ pub fn oncoprint(
                     }
                     1 => rec.extend(filter_canonical.iter().map(|(r, _)| r.clone())),
                     _ => {
-                        rec.extend(filter_canonical.iter().map(|(r, _)| r.clone()));
-                        warn!("Found more than one variant annotated as canonical!");
+                        rec.extend(filter_canonical.iter().map(|(r, _)| {
+                            dbg!(&r);
+                            r.clone()
+                        }));
+                        let alterations = filter_canonical
+                            .iter()
+                            .map(|(r, _)| r.alteration.clone())
+                            .collect_vec();
+                        warn!("Found more than one variant of gene {} annotated as canonical! The alterations marked as canonical are: {:?}", &k, &alterations);
                     }
                 }
             }

--- a/src/bcf/report/oncoprint.rs
+++ b/src/bcf/report/oncoprint.rs
@@ -373,12 +373,12 @@ pub fn oncoprint(
                     1 => rec.extend(filter_canonical.iter().map(|(r, _, _)| r.clone())),
                     _ => {
                         rec.extend(filter_canonical.iter().map(|(r, _, _)| r.clone()));
-                        let transcripts = filter_canonical
+                        let alterations = filter_canonical
                             .iter()
                             .map(|(r, _, _)| r.alteration.clone())
                             .collect_vec();
                         let positions = filter_canonical.iter().map(|(_, _, p)| p).collect_vec();
-                        warn!("Found more than one variant of gene {} annotated as canonical! The transcripts marked as canonical are {:?} located at {:?}", &k, &transcripts, &positions);
+                        warn!("Found more than one transcript in gene {} annotated as canonical! The corresponding alterations are {:?}, located at {:?}", &k, &alterations, &positions);
                     }
                 }
             }


### PR DESCRIPTION
This PR changes behaviour for multiple canonical records per gene in the vcf-report so that rbt only prints a warning and plots all canonical records instead of panicking  right away.