### PR TITLE
Fix anyhow errors for table-report

### DIFF
--- a/src/bcf/report/table_report/create_report_table.rs
+++ b/src/bcf/report/table_report/create_report_table.rs
@@ -72,7 +72,7 @@ pub(crate) fn make_table_report(
         ann_indices.insert(field, i);
     }
 
-    let reference_lengths = get_fasta_lengths(fasta_path);
+    let reference_lengths = get_fasta_lengths(fasta_path)?;
 
     let last_gene_index = get_gene_ending(
         vcf_path,

--- a/src/bcf/report/table_report/fasta_reader.rs
+++ b/src/bcf/report/table_report/fasta_reader.rs
@@ -40,13 +40,13 @@ pub fn read_fasta(
     Ok(fasta)
 }
 
-pub fn get_fasta_lengths(path: &Path) -> HashMap<String, u64> {
-    let index = fasta::Index::with_fasta_file(&path).unwrap();
+pub fn get_fasta_lengths(path: &Path) -> Result<HashMap<String, u64>> {
+    let index = fasta::Index::with_fasta_file(&path).context("error reading input FASTA")?;
     let sequences = index.sequences();
-    sequences
+    Ok(sequences
         .iter()
         .map(|s| (s.name.to_owned(), s.len))
-        .collect()
+        .collect())
 }
 
 #[derive(Serialize, Clone, Debug, PartialEq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,7 +197,9 @@ fn main() -> Result<()> {
                     max_read_depth,
                     js_file_names.clone(),
                 )
-                .unwrap_or_else(|_| panic!("Failed building table report for sample {}", sample));
+                .unwrap_or_else(|e| {
+                    panic!("Failed building table report for sample {}. {}", sample, e)
+                });
             });
 
             bcf::report::oncoprint::oncoprint(


### PR DESCRIPTION
This PR fixes a problem with anyhow errors not being shown caused by this line:

https://github.com/rust-bio/rust-bio-tools/blob/1f337758a9d7a9c6d1b69eb25aea1972dd4cd0e9/src/main.rs#L200

I also added a missing anyhow error context for retrieving fasta lengths.