### PR TITLE
fix: Missing lowercase reference bases in reports

### DIFF
--- a/src/bam/plot/bam_plot.html.tera
+++ b/src/bam/plot/bam_plot.html.tera
@@ -51,7 +51,7 @@
 </nav>
 
 {% for plot in plots %}<div id="collapse_{{loop.index}}" class="row justify-content-center collapse show" style="margin-top: 25px;">
-    <div id="plot_{{loop.index}}" style="overflow-y: auto; height: calc(50vh - 50px);"></div>
+    <div id="plot_{{loop.index}}" style="overflow-y: auto; height: {% if bam.len() > 1 %}calc(50vh - 50px){% else %}calc(100vh - 50px){% endif %};"></div>
 </div>{% endfor %}
 <script>
     let plots = [{% for plot in plots %}{{ plot | safe }}{% if not loop.last %},{% endif %}{% endfor %}];

--- a/src/bam/plot/bam_plot.html.tera
+++ b/src/bam/plot/bam_plot.html.tera
@@ -51,7 +51,7 @@
 </nav>
 
 {% for plot in plots %}<div id="collapse_{{loop.index}}" class="row justify-content-center collapse show" style="margin-top: 25px;">
-    <div id="plot_{{loop.index}}" style="overflow-y: auto; height: {% if bam.len() > 1 %}calc(50vh - 50px){% else %}calc(100vh - 50px){% endif %};"></div>
+    <div id="plot_{{loop.index}}" style="overflow-y: auto; height: {% if bams|length > 1 %}calc(50vh - 50px){% else %}calc(100vh - 50px){% endif %};"></div>
 </div>{% endfor %}
 <script>
     let plots = [{% for plot in plots %}{{ plot | safe }}{% if not loop.last %},{% endif %}{% endfor %}];

--- a/src/bcf/report/table_report/fasta_reader.rs
+++ b/src/bcf/report/table_report/fasta_reader.rs
@@ -26,10 +26,11 @@ pub fn read_fasta<P: AsRef<Path>>(
         ind += 1;
     }
     for a in seq {
+        let base = char::from(a).to_uppercase().collect(); // TODO: Plot lowercase bases (masking repeats) with lower opacity
         let b = Nucleobase {
             start_position: ind as f64 - 0.5,
             end_position: ind as f64 + 0.5,
-            marker_type: a as char,
+            marker_type: base,
             row: 0,
         };
         fasta.push(b);

--- a/src/bcf/report/table_report/fasta_reader.rs
+++ b/src/bcf/report/table_report/fasta_reader.rs
@@ -2,6 +2,7 @@ use crate::common::Region;
 use anyhow::Context;
 use anyhow::Result;
 use bio::io::fasta;
+use itertools::Itertools;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::path::Path;
@@ -26,7 +27,8 @@ pub fn read_fasta<P: AsRef<Path>>(
         ind += 1;
     }
     for a in seq {
-        let base = char::from(a).to_uppercase().collect(); // TODO: Plot lowercase bases (masking repeats) with lower opacity
+        // TODO: Plot lowercase bases (masking repeats) with lower opacity
+        let base = char::from(a).to_uppercase().collect_vec().pop().unwrap();
         let b = Nucleobase {
             start_position: ind as f64 - 0.5,
             end_position: ind as f64 + 0.5,


### PR DESCRIPTION
This PR adds missing lowercase reference bases in plots for `rbt vcf-report` and `rbt plot-bam`. It also includes a quick improvement of the plot height of `rbt plot-bam` when there is only one given sample. 