### PR TITLE
fix: Prevent release PR on forks

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,7 @@ name: release-please
 
 jobs:
   release-please:
+    if: github.repository_owner == 'rust-bio'
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
This should prevent PRs like [this one](https://github.com/fxwiegand/rust-bio-tools/pull/2). Not sure whether this is the most elegant way to deal with this. I've had a look at the configuration section in the [Release Please Documentation](https://github.com/google-github-actions/release-please-action) and only found a fork option (which should be `false` by default) that decides whether the PR is created **from** a fork but not **inside** one.  @johanneskoester let me know if you have a better idea! 😅