### PR TITLE
feat: Mark repeats in reference with lower opacity

### DIFF
--- a/src/bcf/report/table_report/fasta_reader.rs
+++ b/src/bcf/report/table_report/fasta_reader.rs
@@ -27,13 +27,14 @@ pub fn read_fasta<P: AsRef<Path>>(
         ind += 1;
     }
     for a in seq {
-        // TODO: Plot lowercase bases (masking repeats) with lower opacity
-        let base = char::from(a).to_uppercase().collect_vec().pop().unwrap();
+        let base = char::from(a);
+        let marker = base.to_uppercase().collect_vec().pop().unwrap();
         let b = Nucleobase {
             start_position: ind as f64 - 0.5,
             end_position: ind as f64 + 0.5,
-            marker_type: base,
+            marker_type: marker,
             row: 0,
+            repeat: base.is_lowercase(),
         };
         fasta.push(b);
         ind += 1;
@@ -57,6 +58,7 @@ pub struct Nucleobase {
     end_position: f64,
     marker_type: char,
     row: u8,
+    repeat: bool,
 }
 
 impl Nucleobase {

--- a/src/bcf/report/table_report/vegaSpecs.json
+++ b/src/bcf/report/table_report/vegaSpecs.json
@@ -205,9 +205,7 @@
             "scale": "color",
             "field": "marker_type"
           },
-          "opacity": {
-            "value": 0.8
-          },
+          "opacity": {"scale": "opac", "field": "repeat"},
           "tooltip": {
             "signal": "{\"type\": datum[\"typ\"], \"base\": datum[\"base\"], \"variant type\": datum[\"var_type\"],\"test\": datum[\"test\"], \"inserted base(s)\": datum[\"inserts\"], \"reference\": datum[\"reference\"], \"alternatives\": datum[\"alternatives\"], \"name\": datum[\"name\"], \"flag 1\": (datum[\"flags\"] || {})[\"1\"], \"flag 2\": (datum[\"flags\"] || {})[\"2\"], \"flag 4\": (datum[\"flags\"] || {})[\"4\"], \"flag 8\": (datum[\"flags\"] || {})[\"8\"], \"flag 16\": (datum[\"flags\"] || {})[\"16\"], \"flag 32\": (datum[\"flags\"] || {})[\"32\"], \"flag 64\": (datum[\"flags\"] || {})[\"64\"], \"flag 128\": (datum[\"flags\"] || {})[\"128\"], \"flag 256\": (datum[\"flags\"] || {})[\"256\"], \"flag 512\": (datum[\"flags\"] || {})[\"512\"], \"flag 1024\": (datum[\"flags\"] || {})[\"1024\"], \"flag 2048\": (datum[\"flags\"] || {})[\"2048\"]}"
           },
@@ -372,6 +370,15 @@
         5,
         1
       ]
+    },
+    {
+      "name": "opac",
+      "type": "ordinal",
+      "domain": [
+        true,
+        false
+      ],
+      "range": [0.4, 0.9]
     },
     {
       "name": "color",


### PR DESCRIPTION
This PR marks lowercase bases as repeats with lower opacity in all vega plots generated with `rbt plot-bam` and `rbt vcf-report`.