### PR TITLE
fix: Adjust FASTA read interval

### DIFF
--- a/src/bcf/report/table_report/create_report_table.rs
+++ b/src/bcf/report/table_report/create_report_table.rs
@@ -337,7 +337,7 @@ pub(crate) fn make_table_report(
                         )?;
                         visualization =
                             manipulate_json(content, 0, end_position as u64 + 75, max_rows)?;
-                    } else if pos + 75 >= fasta_length as i64 {
+                    } else if end_position as i64 + 75 >= fasta_length as i64 {
                         let (content, max_rows) = create_report_data(
                             fasta_path,
                             Some(var.clone()),


### PR DESCRIPTION
This PR fixes a bug in `rbt vcf-report` where the `FASTA read interval was out of bounds` for long variants positioned at the end of the given FASTA reference. 