### PR TITLE
fix: Cosmic link

### DIFF
--- a/src/bcf/report/js/table-report.js
+++ b/src/bcf/report/js/table-report.js
@@ -98,8 +98,7 @@ $(document).ready(function () {
                                 let num = val.replace( /^\D+/g, '');
                                 result = result + "<a href='https://cancer.sanger.ac.uk/cosmic/ncv/overview?id=" + num + "'>" + val + "</a>";
                             } else if (val.startsWith("COSV")) {
-                                let num = val.replace( /^\D+/g, '');
-                                result = result + "<a href='https://cancer.sanger.ac.uk/cosmic/search?q=" + num + "'>" + val + "</a>";
+                                result = result + "<a href='https://cancer.sanger.ac.uk/cosmic/search?q=" + val + "'>" + val + "</a>";
                             } else {
                                 result = result + val;
                             }


### PR DESCRIPTION
In the previous PR a Cosmic link for Cosmic-IDs starting with `COSV` had been added.
Unintentionally the `COSV` prefix had been striped from the ID causing the link to be invalid.