### PR TITLE
fix: Respect target CPU compat via rocksdb ^0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 uuid = { version = "0.7", features = ["v4"] }
 tempfile = "3.0"
-rocksdb = "0.16"
+rocksdb = "0.17"
 ordered-float = "0.5"
 flate2 = "1.0.5"
 streaming-stats =  "0.2.2"


### PR DESCRIPTION
- SSE instructions are used according to the target CPU specifications
- via https://github.com/rust-rocksdb/rust-rocksdb/pull/526
- fixes https://github.com/bioconda/bioconda-recipes/pull/28719