### PR TITLE
fix: improved handling of softclips

### DIFF
--- a/src/bam/collapse_reads_to_fragments/pipeline.rs
+++ b/src/bam/collapse_reads_to_fragments/pipeline.rs
@@ -546,8 +546,12 @@ fn calc_alignment_vectors(
 }
 
 fn cigar_has_softclips(rec: &bam::Record) -> bool {
-    let cigar = rec.cigar_cached().unwrap();
-    cigar.leading_softclips() > 0 || cigar.trailing_softclips() > 0
+    for cigar_operation in rec.cigar_cached().unwrap().iter() {
+        if let bam::record::Cigar::SoftClip(_) = cigar_operation {
+            return true;
+        }
+    }
+    false
 }
 
 fn match_single_cigar(cigar: &Option<char>, first_vec: &mut Vec<bool>, second_vec: &mut Vec<bool>) {

--- a/src/bcf/report/table_report/static_reader.rs
+++ b/src/bcf/report/table_report/static_reader.rs
@@ -56,9 +56,9 @@ fn calc_rows(
     let mut max_row = 0;
 
     for r in matches {
-        let overlaps = if variant.is_some() {
-            r.read_start < variant.unwrap().start_position as u32
-                && r.read_end > variant.unwrap().end_position as u32
+        let overlaps = if let Some(variant_entry) = variant {
+            r.read_start < variant_entry.start_position as u32
+                && r.read_end > variant_entry.end_position as u32
         } else {
             true
         };
@@ -92,9 +92,9 @@ fn calc_rows(
     }
 
     for r in reads {
-        let overlaps = if variant.is_some() {
-            r.read_start < variant.unwrap().start_position as u32
-                && r.read_end > variant.unwrap().end_position as u32
+        let overlaps = if let Some(variant_entry) = variant {
+            r.read_start < variant_entry.start_position as u32
+                && r.read_end > variant_entry.end_position as u32
         } else {
             true
         };

--- a/src/csv/report.rs
+++ b/src/csv/report.rs
@@ -146,7 +146,7 @@ pub(crate) fn csv_report(
 
     wb.close()?;
 
-    let pages = if table.len() % rows_per_page == 0 && table.len() > 0 {
+    let pages = if table.len() % rows_per_page == 0 && !table.is_empty() {
         (table.len() / rows_per_page) - 1
     } else {
         table.len() / rows_per_page


### PR DESCRIPTION
This PR improves handling of softclips when executing `collapse_reads_to_fragments`.
Initially reads were skipped in case starting or trailing softclips as building consensus sequences might be non-deterministic.
Now, it turned out that softclips may also occur after hardclips (in case of primer trimming using fgbio).
In that case `collapse_reads_to_fragments` will fail as these reads won't be skipped.
To fix this cigar string will now be fully checked for softclips.

This PR also includes applies some clippy lints.