### PR TITLE
feat: simulate reads from real bam files

### DIFF
--- a/src/bam/anonymize_reads.rs
+++ b/src/bam/anonymize_reads.rs
@@ -9,7 +9,7 @@ use std::ops::Range;
 use std::path::Path;
 use uuid::Uuid;
 
-pub fn simulate_reads<P: AsRef<Path>>(
+pub fn anonymize_reads<P: AsRef<Path>>(
     bam: P,
     input_ref: P,
     output_bam: P,

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -1,5 +1,5 @@
 //! Tools that work on BAM files
+pub mod anonymize_reads;
 pub mod collapse_reads_to_fragments;
 pub mod depth;
 pub mod plot;
-pub mod simulate_reads;

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -2,3 +2,4 @@
 pub mod collapse_reads_to_fragments;
 pub mod depth;
 pub mod plot;
+pub mod simulate_reads;

--- a/src/bam/simulate_reads.rs
+++ b/src/bam/simulate_reads.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use bio::io::fasta;
+use rand::prelude::ThreadRng;
 use rand::Rng;
 use rust_htslib::bam;
 use rust_htslib::bam::Read;
@@ -16,13 +17,15 @@ pub fn simulate_reads<P: AsRef<Path>>(
     end: u64,
 ) -> Result<()> {
     let mut fasta_reader = fasta::IndexedReader::from_file(&input_ref)?;
-    fasta_reader.fetch(&chr, start - 1, end)?;
+    fasta_reader.fetch(&chr, start - 1, end - 1)?;
     let mut reference = Vec::new();
     fasta_reader.read(&mut reference)?;
+    let mut rng = rand::thread_rng();
+    let alphabet = [b'A', b'C', b'G', b'T'];
 
     //Build artificial reference
     let mut artificial_reference = Vec::new();
-    add_random_bases(end - start, &mut artificial_reference)?;
+    add_random_bases(end - start, &mut artificial_reference, &mut rng, &alphabet)?;
     let mut fa_writer = fasta::Writer::to_file(output_ref)?;
     let ref_id = Uuid::new_v4().to_hyphenated().to_string();
     fa_writer.write(&ref_id, None, &artificial_reference)?;
@@ -39,7 +42,8 @@ pub fn simulate_reads<P: AsRef<Path>>(
     let mut bam_writer = bam::Writer::from_path(output_bam, &header, bam::Format::BAM)?;
     for result in bam_reader.records() {
         let mut record = result?;
-        if (record.cigar().end_pos() <= (end as i64))
+        if (record.pos() >= (start - 1) as i64)
+            && (record.cigar().end_pos() < (end - 1) as i64)
             && (record.mtid() == record.tid())
             && (record.mpos() + 1 >= (start as i64))
             && (record.mpos() + 1 < (end as i64))
@@ -49,7 +53,7 @@ pub fn simulate_reads<P: AsRef<Path>>(
             //Check if mate record end within region
             let artificial_seq = if record.is_unmapped() {
                 let mut seq = Vec::new();
-                add_random_bases(record.seq_len() as u64, &mut seq)?;
+                add_random_bases(record.seq_len() as u64, &mut seq, &mut rng, &alphabet)?;
                 seq
             } else {
                 build_sequence(
@@ -57,6 +61,8 @@ pub fn simulate_reads<P: AsRef<Path>>(
                     &artificial_reference,
                     &record,
                     (start - 1) as usize,
+                    &mut rng,
+                    &alphabet,
                 )?
             };
             let artificial_record = build_record(&record, &artificial_seq, (start - 1) as i64)?;
@@ -86,21 +92,26 @@ fn build_record(record: &bam::Record, artificial_seq: &[u8], offset: i64) -> Res
     artificial_record.set_mapq(record.mapq());
     Ok(artificial_record)
 }
+
 fn build_sequence(
     reference: &[u8],
     artificial_reference: &[u8],
     record: &bam::Record,
     offset: usize,
+    rng: &mut ThreadRng,
+    alphabet: &[u8],
 ) -> Result<Vec<u8>> {
     let mut artificial_seq = Vec::new();
     let record_seq = record.seq().as_bytes();
     let mut record_pos = 0;
+    dbg!(record.pos());
+    dbg!(offset);
     let mut ref_pos = record.pos() as usize - offset;
     //Create random seq for leading softclips
     for cigar in record.cigar_cached().unwrap().iter() {
         match cigar.char() {
             'S' => {
-                add_random_bases(cigar.len() as u64, &mut artificial_seq)?;
+                add_random_bases(cigar.len() as u64, &mut artificial_seq, rng, alphabet)?;
                 record_pos += cigar.len() as usize;
             }
             'M' => {
@@ -109,7 +120,9 @@ fn build_sequence(
                     if record_seq.get(record_pos).unwrap() == reference.get(ref_pos).unwrap() {
                         artificial_seq.push(*ref_base);
                     } else {
-                        add_random_base(&mut artificial_seq, ref_base);
+                        let mut reduced_alphabet = alphabet.to_vec();
+                        reduced_alphabet.retain(|x| x != ref_base);
+                        add_random_bases(1, &mut artificial_seq, rng, &reduced_alphabet).unwrap();
                     }
                     ref_pos += 1;
                     record_pos += 1;
@@ -117,7 +130,7 @@ fn build_sequence(
                 // Add reference bases except for mismatches
             }
             'I' => {
-                add_random_bases(cigar.len() as u64, &mut artificial_seq)?;
+                add_random_bases(cigar.len() as u64, &mut artificial_seq, rng, alphabet)?;
                 record_pos += cigar.len() as usize;
             }
             'D' | 'N' => {
@@ -126,7 +139,9 @@ fn build_sequence(
             'X' => {
                 (0..cigar.len()).for_each(|_| {
                     let ref_base = artificial_reference.get(ref_pos).unwrap();
-                    add_random_base(&mut artificial_seq, ref_base);
+                    let mut reduced_alphabet = alphabet.to_vec();
+                    reduced_alphabet.retain(|x| x != ref_base);
+                    add_random_bases(1, &mut artificial_seq, rng, &reduced_alphabet).unwrap();
                     ref_pos += 1;
                 });
                 record_pos += cigar.len() as usize;
@@ -146,19 +161,15 @@ fn build_sequence(
     Ok(artificial_seq)
 }
 
-fn add_random_base(seq: &mut Vec<u8>, excluded_base: &u8) {
-    let mut rng = rand::thread_rng();
-    let mut alphabet = vec![b'A', b'C', b'G', b'T'];
-    alphabet.retain(|x| x != excluded_base);
-    let idx = rng.gen_range(0, 3);
-    seq.push(alphabet[idx]);
-}
-
-fn add_random_bases(length: u64, seq: &mut Vec<u8>) -> Result<()> {
-    let alphabet = [b'A', b'C', b'G', b'T'];
-    let mut rng = rand::thread_rng();
+fn add_random_bases(
+    length: u64,
+    seq: &mut Vec<u8>,
+    rng: &mut ThreadRng,
+    alphabet: &[u8],
+) -> Result<()> {
+    let alphabet_size = alphabet.len();
     (0..length).for_each(|_| {
-        let idx = rng.gen_range(0, 4);
+        let idx = rng.gen_range(0, alphabet_size);
         seq.push(alphabet[idx])
     });
     Ok(())

--- a/src/bam/simulate_reads.rs
+++ b/src/bam/simulate_reads.rs
@@ -104,10 +104,9 @@ fn build_sequence(
     let mut artificial_seq = Vec::new();
     let record_seq = record.seq().as_bytes();
     let mut record_pos = 0;
-    dbg!(record.pos());
-    dbg!(offset);
     let mut ref_pos = record.pos() as usize - offset;
     //Create random seq for leading softclips
+    let mut ref_base = artificial_reference.get(ref_pos).unwrap();
     for cigar in record.cigar_cached().unwrap().iter() {
         match cigar.char() {
             'S' => {
@@ -116,7 +115,7 @@ fn build_sequence(
             }
             'M' => {
                 (0..cigar.len()).for_each(|_| {
-                    let ref_base = artificial_reference.get(ref_pos).unwrap();
+                    ref_base = artificial_reference.get(ref_pos).unwrap();
                     if record_seq.get(record_pos).unwrap() == reference.get(ref_pos).unwrap() {
                         artificial_seq.push(*ref_base);
                     } else {
@@ -138,7 +137,7 @@ fn build_sequence(
             }
             'X' => {
                 (0..cigar.len()).for_each(|_| {
-                    let ref_base = artificial_reference.get(ref_pos).unwrap();
+                    ref_base = artificial_reference.get(ref_pos).unwrap();
                     let mut reduced_alphabet = alphabet.to_vec();
                     reduced_alphabet.retain(|x| x != ref_base);
                     add_random_bases(1, &mut artificial_seq, rng, &reduced_alphabet).unwrap();

--- a/src/bam/simulate_reads.rs
+++ b/src/bam/simulate_reads.rs
@@ -39,7 +39,7 @@ pub fn simulate_reads<P: AsRef<Path>>(
             .push_tag(b"SN", &ref_id)
             .push_tag(b"LN", &(end - start)),
     );
-    let mut bam_writer = bam::Writer::from_path(output_bam, &header, bam::Format::BAM)?;
+    let mut bam_writer = bam::Writer::from_path(output_bam, &header, bam::Format::Bam)?;
     for result in bam_reader.records() {
         let mut record = result?;
         if (record.pos() >= (start - 1) as i64)
@@ -74,8 +74,8 @@ pub fn simulate_reads<P: AsRef<Path>>(
 
 fn build_record(record: &bam::Record, artificial_seq: &[u8], offset: i64) -> Result<bam::Record> {
     let mut artificial_record = bam::record::Record::new();
-    if let Some(mate_cigar) = record.aux(b"MC") {
-        artificial_record.push_aux(b"MC", &mate_cigar);
+    if let Ok(mate_cigar) = record.aux(b"MC") {
+        artificial_record.push_aux(b"MC", mate_cigar)?;
     }
     artificial_record.set(
         record.qname(),

--- a/src/bam/simulate_reads.rs
+++ b/src/bam/simulate_reads.rs
@@ -1,0 +1,144 @@
+use anyhow::Result;
+use bio::io::fasta;
+use rand::Rng;
+use rust_htslib::bam;
+use rust_htslib::bam::Read;
+use std::path::Path;
+use uuid::Uuid;
+
+pub fn simulate_reads<P: AsRef<Path>>(
+    bam: P,
+    input_ref: P,
+    output_bam: P,
+    output_ref: P,
+    chr: String,
+    start: u64,
+    end: u64,
+) -> Result<()> {
+    let mut fasta_reader = fasta::IndexedReader::from_file(&input_ref)?;
+    fasta_reader.fetch(&chr, start, end)?;
+    let mut reference = Vec::new();
+    fasta_reader.read(&mut reference)?;
+
+    //Build artificial reference
+    let mut artificial_reference = Vec::new();
+    add_random_bases(end - start, &mut artificial_reference)?;
+    let mut fa_writer = fasta::Writer::to_file(output_ref)?;
+    let ref_id = Uuid::new_v4().to_hyphenated().to_string();
+    fa_writer.write(&ref_id, None, &artificial_reference)?;
+
+    let mut bam_reader = bam::IndexedReader::from_path(bam)?;
+    bam_reader.fetch((chr.as_bytes(), start, end))?;
+
+    let mut header = bam::Header::new();
+    header.push_record(
+        bam::header::HeaderRecord::new(b"SQ")
+            .push_tag(b"SN", &ref_id)
+            .push_tag(b"LN", &(end - start)),
+    );
+    let mut bam_writer = bam::Writer::from_path(output_bam, &header, bam::Format::BAM)?;
+    for result in bam_reader.records() {
+        let mut record = result?;
+        if (record.cigar().end_pos() < (end as i64))
+            && (record.mtid() == record.tid())
+            && (record.mpos() >= (start as i64))
+            && (record.mpos() < (end as i64))
+        {
+            record.cache_cigar();
+            //Check if mate record end within region
+            let artifical_seq =
+                build_sequence(&reference, &artificial_reference, &record, start as usize)?;
+            let mut artifical_record = bam::record::Record::new();
+            artifical_record.set(
+                record.qname(),
+                Some(&record.cigar()),
+                &artifical_seq,
+                record.qual(),
+            );
+            artifical_record.set_pos(record.pos() - start as i64);
+            artifical_record.set_tid(0);
+            artifical_record.set_mtid(0);
+            artifical_record.set_mpos(record.mpos() - start as i64);
+            bam_writer.write(&artifical_record)?;
+        }
+    }
+    Ok(())
+}
+
+fn build_sequence(
+    reference: &[u8],
+    artificial_reference: &[u8],
+    record: &bam::Record,
+    offset: usize,
+) -> Result<Vec<u8>> {
+    let mut artificial_seq = Vec::new();
+    let record_seq = record.seq();
+    let mut record_pos = 0;
+    let mut ref_pos = record.pos() as usize - offset;
+    //Create random seq for leading softclips
+    for cigar in record.cigar_cached().unwrap().iter() {
+        match cigar.char() {
+            'S' => {
+                add_random_bases(cigar.len() as u64, &mut artificial_seq)?;
+                //Add random Sequence of length cigar.len()
+            }
+            'M' => {
+                (0..cigar.len()).for_each(|_| {
+                    let ref_base = artificial_reference.get(ref_pos).unwrap();
+                    if record_seq.encoded_base(record_pos) == *reference.get(ref_pos).unwrap() {
+                        artificial_seq.push(*artificial_reference.get(ref_pos).unwrap());
+                    } else {
+                        add_random_base(&mut artificial_seq, ref_base);
+                    }
+                    ref_pos += 1;
+                    record_pos += 1;
+                });
+                // Add reference bases except for mismatches
+            }
+            'I' => {
+                add_random_bases(cigar.len() as u64, &mut artificial_seq)?;
+                record_pos += cigar.len() as usize;
+            }
+            'D' | 'N' => {
+                ref_pos += cigar.len() as usize;
+            }
+            'X' => {
+                (0..cigar.len()).for_each(|_| {
+                    let ref_base = artificial_reference.get(ref_pos).unwrap();
+                    add_random_base(&mut artificial_seq, ref_base);
+                    ref_pos += 1;
+                });
+                record_pos += cigar.len() as usize;
+            }
+            '=' => {
+                (0..cigar.len()).for_each(|_| {
+                    let ref_base = artificial_reference.get(ref_pos).unwrap();
+                    artificial_seq.push(*ref_base);
+                    ref_pos += 1;
+                });
+                record_pos += cigar.len() as usize;
+            }
+            _ => {}
+        }
+    }
+
+    Ok(artificial_seq)
+}
+
+fn add_random_base(seq: &mut Vec<u8>, excluded_base: &u8) {
+    let mut rng = rand::thread_rng();
+    let mut alphabet = vec![b'A', b'C', b'G', b'T'];
+    alphabet.retain(|x| x != excluded_base);
+    let idx = rng.gen_range(0, 3);
+    seq.push(alphabet[idx]);
+}
+
+fn add_random_bases(length: u64, seq: &mut Vec<u8>) -> Result<()> {
+    let alphabet = [b'A', b'C', b'G', b'T'];
+    let mut rng = rand::thread_rng();
+    (0..length).for_each(|_| {
+        let idx = rng.gen_range(0, 4);
+        seq.push(alphabet[idx])
+    });
+    Ok(())
+}

--- a/src/bam/simulate_reads.rs
+++ b/src/bam/simulate_reads.rs
@@ -39,7 +39,7 @@ pub fn simulate_reads<P: AsRef<Path>>(
     let mut bam_writer = bam::Writer::from_path(output_bam, &header, bam::Format::BAM)?;
     for result in bam_reader.records() {
         let mut record = result?;
-        if (record.pos() > start as i64)
+        if (record.pos() >= start as i64)
             && (record.cigar().end_pos() < (end as i64))
             && (!record.is_unmapped())
             && (!record.is_mate_unmapped())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -355,6 +355,12 @@ pub(crate) enum Command {
         start: u64,
         #[structopt(help = "1-based exclusive end position")]
         end: u64,
+        #[structopt(
+            long,
+            short = "p",
+            help = "Only simulates reads whos mates are both in defined range."
+        )]
+        pairs: bool,
     },
 
     /// Tool to compute stats on sequence file (from STDIN), output is in YAML with fields:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -335,6 +335,28 @@ pub(crate) enum Command {
         cmd: CollapseReadsToFragmentsSubcommand,
     },
 
+    /// Tool to build artifical reads from real BAM files with identical properties.
+    #[structopt(author = "Felix Mölder <felix.moelder@uni-due.de>")]
+    SimulateReads {
+        #[structopt(parse(from_os_str), help = "Input BAM file")]
+        bam: PathBuf,
+        #[structopt(parse(from_os_str), help = "Input reference as fasta file")]
+        input_ref: PathBuf,
+        #[structopt(parse(from_os_str), help = "Output BAM file with artificial reads")]
+        output_bam: PathBuf,
+        #[structopt(
+            parse(from_os_str),
+            help = "Output fasta file with artificial reference"
+        )]
+        output_ref: PathBuf,
+        #[structopt(help = "chromosome name")]
+        chr: String,
+        #[structopt(help = "0-based start position")]
+        start: u64,
+        #[structopt(help = "0-based exclusive end position")]
+        end: u64,
+    },
+
     /// Tool to compute stats on sequence file (from STDIN), output is in YAML with fields:
     /// - min: length of shortest sequence
     /// - max: length of longest sequence

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -337,7 +337,7 @@ pub(crate) enum Command {
 
     /// Tool to build artifical reads from real BAM files with identical properties.
     #[structopt(author = "Felix Mölder <felix.moelder@uni-due.de>")]
-    SimulateReads {
+    BamAnonymize {
         #[structopt(parse(from_os_str), help = "Input BAM file")]
         bam: PathBuf,
         #[structopt(parse(from_os_str), help = "Input reference as fasta file")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -351,9 +351,9 @@ pub(crate) enum Command {
         output_ref: PathBuf,
         #[structopt(help = "chromosome name")]
         chr: String,
-        #[structopt(help = "0-based start position")]
+        #[structopt(help = "1-based start position")]
         start: u64,
-        #[structopt(help = "0-based exclusive end position")]
+        #[structopt(help = "1-based exclusive end position")]
         end: u64,
     },
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -360,7 +360,7 @@ pub(crate) enum Command {
             short = "p",
             help = "Only simulates reads whos mates are both in defined range."
         )]
-        pairs: bool,
+        keep_only_pairs: bool,
     },
 
     /// Tool to compute stats on sequence file (from STDIN), output is in YAML with fields:

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,6 +261,17 @@ fn main() -> Result<()> {
                 verbose_read_names,
             )?,
         },
+        SimulateReads {
+            bam,
+            input_ref,
+            output_bam,
+            output_ref,
+            chr,
+            start,
+            end,
+        } => bam::simulate_reads::simulate_reads(
+            bam, input_ref, output_bam, output_ref, chr, start, end,
+        )?,
         SequenceStats { fastq } => sequences_stats::stats(fastq)?,
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -269,7 +269,7 @@ fn main() -> Result<()> {
             chr,
             start,
             end,
-            pairs,
+            keep_only_pairs,
         } => bam::simulate_reads::simulate_reads(
             bam,
             input_ref,
@@ -277,7 +277,7 @@ fn main() -> Result<()> {
             output_ref,
             chr,
             start - 1..end - 1,
-            pairs,
+            keep_only_pairs,
         )?,
         SequenceStats { fastq } => sequences_stats::stats(fastq)?,
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -269,8 +269,9 @@ fn main() -> Result<()> {
             chr,
             start,
             end,
+            pairs,
         } => bam::simulate_reads::simulate_reads(
-            bam, input_ref, output_bam, output_ref, chr, start, end,
+            bam, input_ref, output_bam, output_ref, chr, start, end, pairs,
         )?,
         SequenceStats { fastq } => sequences_stats::stats(fastq)?,
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,7 +271,13 @@ fn main() -> Result<()> {
             end,
             pairs,
         } => bam::simulate_reads::simulate_reads(
-            bam, input_ref, output_bam, output_ref, chr, start, end, pairs,
+            bam,
+            input_ref,
+            output_bam,
+            output_ref,
+            chr,
+            start - 1..end - 1,
+            pairs,
         )?,
         SequenceStats { fastq } => sequences_stats::stats(fastq)?,
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,7 +261,7 @@ fn main() -> Result<()> {
                 verbose_read_names,
             )?,
         },
-        SimulateReads {
+        BamAnonymize {
             bam,
             input_ref,
             output_bam,
@@ -270,7 +270,7 @@ fn main() -> Result<()> {
             start,
             end,
             keep_only_pairs,
-        } => bam::simulate_reads::simulate_reads(
+        } => bam::anonymize_reads::anonymize_reads(
             bam,
             input_ref,
             output_bam,


### PR DESCRIPTION
This PR adds a subcommand `rbt simulate-reads` allowing to derive artificial bam files from real ones.
The user has to define a region from which reads will be drawn. (Only read pairs that are completely within the region will be considered.)
For this region a random reference sequence will be created.
Artificial reads will then be derived from this random reference by comparing the original read sequence to the reference (based on cigar operations).
Mismatching bases are replaced by random ones that differ from the reference.
The final reads contain random sequences with positions readjusted to the new reference.
The following attributes will be adopted from the original read:

- read name
- base qualities
- flags
- CIGAR-String
- insert size
- MC tag

Creating artificial reads allows to provide test data often need for e.g. issueing bug reports without leaking any patient related information.