### PR TITLE
fix: fix DI tag when building consensus reads

### DIFF
--- a/src/bam/collapse_reads_to_fragments/pipeline.rs
+++ b/src/bam/collapse_reads_to_fragments/pipeline.rs
@@ -79,6 +79,7 @@ impl<W: io::Write> CallConsensusRead<W> {
             }
             record.cache_cigar();
             let duplicate_id_option = match record.aux(b"DI") {
+                Ok(Aux::I8(duplicate_id)) => Some(duplicate_id as u32),
                 Ok(Aux::U8(duplicate_id)) => Some(duplicate_id as u32),
                 Ok(Aux::U16(duplicate_id)) => Some(duplicate_id as u32),
                 Ok(Aux::U32(duplicate_id)) => Some(duplicate_id),


### PR DESCRIPTION
It turned out that auxiliary entries of a `DI` record can also be typed as `Aux::I8` by rust-htslib.
To handle this it has also been included for type casting.