### PR TITLE
fix: Refine MAPQ color scheme and scale type

### DIFF
--- a/src/bcf/report/table_report/vegaSpecs.json
+++ b/src/bcf/report/table_report/vegaSpecs.json
@@ -521,7 +521,7 @@
       "name": "color2",
       "type": "bin-ordinal",
       "domain": [0, 10, 20, 30, 40, 50, 60, 70],
-      "range": ["#900101", "#a62101", "#bc4a01", "#d27c01", "#e9b600", "#fff900", "#bbbbbb"]
+      "range": ["#910000", "#c70002", "#ff0000", "#ff7500", "#ffb200", "#ffe921", "#bbbbbb"]
     },
     {
       "name": "color",


### PR DESCRIPTION
Just a quick follow up to the newly introduced mapq color scale in #187.