### PR TITLE
feat: Show position of reference base in tooltip

### DIFF
--- a/src/bcf/report/table_report/fasta_reader.rs
+++ b/src/bcf/report/table_report/fasta_reader.rs
@@ -31,8 +31,7 @@ pub fn read_fasta<P: AsRef<Path>>(
         let base = char::from(a);
         let marker = base.to_uppercase().collect_vec().pop().unwrap();
         let b = Nucleobase {
-            start_position: ind as f64 - 0.5,
-            end_position: ind as f64 + 0.5,
+            position: ind,
             marker_type: marker,
             row: 0,
             repeat: base.is_lowercase(),
@@ -55,8 +54,7 @@ pub fn get_fasta_lengths(path: &Path) -> Result<HashMap<String, u64>> {
 
 #[derive(Serialize, Clone, Debug, PartialEq)]
 pub struct Nucleobase {
-    start_position: f64,
-    end_position: f64,
+    position: u64,
     marker_type: char,
     row: u8,
     repeat: bool,

--- a/src/bcf/report/table_report/vegaSpecs.json
+++ b/src/bcf/report/table_report/vegaSpecs.json
@@ -32,7 +32,7 @@
       "transform": [
         {
           "type": "filter",
-          "expr": "datum.row >= 0"
+          "expr": "datum.row > 0"
         }, {
           "type": "filter",
           "expr": "datum.marker_type != \"Pairing\""
@@ -45,6 +45,25 @@
           "type": "formula",
           "as": "end_border",
           "expr": "datum.end_position + 0.2"
+        }
+      ]
+    },
+    {
+      "name": "ref",
+      "source": "fasta",
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "datum.row == 0"
+        },{
+          "type": "formula",
+          "as": "start_position",
+          "expr": "datum.position - 0.5"
+        },
+        {
+          "type": "formula",
+          "as": "end_position",
+          "expr": "datum.position + 0.5"
         }
       ]
     },
@@ -317,6 +336,51 @@
           "opacity": {"scale": "opac", "field": "repeat"},
           "tooltip": {
             "signal": "{\"type\": datum[\"typ\"], \"base\": datum[\"base\"], \"variant type\": datum[\"var_type\"],\"test\": datum[\"test\"], \"inserted base(s)\": datum[\"inserts\"], \"reference\": datum[\"reference\"], \"alternatives\": datum[\"alternatives\"], \"name\": datum[\"name\"], \"mapq\": datum[\"mapq\"], \"cigar\": datum[\"cigar\"], \"flag 1\": (datum[\"flags\"] || {})[\"1\"], \"flag 2\": (datum[\"flags\"] || {})[\"2\"], \"flag 4\": (datum[\"flags\"] || {})[\"4\"], \"flag 8\": (datum[\"flags\"] || {})[\"8\"], \"flag 16\": (datum[\"flags\"] || {})[\"16\"], \"flag 32\": (datum[\"flags\"] || {})[\"32\"], \"flag 64\": (datum[\"flags\"] || {})[\"64\"], \"flag 128\": (datum[\"flags\"] || {})[\"128\"], \"flag 256\": (datum[\"flags\"] || {})[\"256\"], \"flag 512\": (datum[\"flags\"] || {})[\"512\"], \"flag 1024\": (datum[\"flags\"] || {})[\"1024\"], \"flag 2048\": (datum[\"flags\"] || {})[\"2048\"]}"
+          },
+          "x": {
+            "scale": "x",
+            "field": "start_position"
+          },
+          "x2": {
+            "scale": "x",
+            "field": "end_position"
+          },
+          "y": {
+            "scale": "y",
+            "field": "row",
+            "band": 0.5
+          },
+          "zindex": {
+            "scale": "z",
+            "field": "marker_type"
+          },
+          "strokeWidth": {
+            "scale": "stroke",
+            "field": "marker_type"
+          }
+        }
+      }
+    },
+    {
+      "name": "refs",
+      "type": "group",
+      "clip": true,
+      "style": [
+        "rule"
+      ],
+      "interactive": true,
+      "from": {
+        "data": "ref"
+      },
+      "encode": {
+        "update": {
+          "stroke": {
+            "scale": "color",
+            "field": "marker_type"
+          },
+          "opacity": {"scale": "opac", "field": "repeat"},
+          "tooltip": {
+            "signal": "{\"base\": datum[\"base\"], \"position\": datum[\"position\"], \"variant type\": datum[\"var_type\"],\"test\": datum[\"test\"], \"inserted base(s)\": datum[\"inserts\"], \"reference\": datum[\"reference\"], \"alternatives\": datum[\"alternatives\"], \"name\": datum[\"name\"], \"flag 1\": (datum[\"flags\"] || {})[\"1\"], \"flag 2\": (datum[\"flags\"] || {})[\"2\"], \"flag 4\": (datum[\"flags\"] || {})[\"4\"], \"flag 8\": (datum[\"flags\"] || {})[\"8\"], \"flag 16\": (datum[\"flags\"] || {})[\"16\"], \"flag 32\": (datum[\"flags\"] || {})[\"32\"], \"flag 64\": (datum[\"flags\"] || {})[\"64\"], \"flag 128\": (datum[\"flags\"] || {})[\"128\"], \"flag 256\": (datum[\"flags\"] || {})[\"256\"], \"flag 512\": (datum[\"flags\"] || {})[\"512\"], \"flag 1024\": (datum[\"flags\"] || {})[\"1024\"], \"flag 2048\": (datum[\"flags\"] || {})[\"2048\"]}"
           },
           "x": {
             "scale": "x",


### PR DESCRIPTION
This PR adds the position of reference bases to the tooltip. It also removes the redundant `start_position` and `end_position` attributes and uses vega transforms instead to generate it.
<img width="222" alt="Bildschirmfoto 2021-11-10 um 11 01 33" src="https://user-images.githubusercontent.com/39430842/141092411-bb261303-310f-4baa-9dd6-acf58ee70939.png">