### PR TITLE
docs: Add `gsl` dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For a list of changes, take a look at the [CHANGELOG](CHANGELOG.md).
 
 ### Requirements
 
-Rust-Bio-Tools depends on [GSL](https://www.gnu.org/software/gsl/) to be installed:
+Rust-Bio-Tools depends [rgsl](https://docs.rs/GSL/*/rgsl/) which needs [GSL](https://www.gnu.org/software/gsl/) to be installed:
 
 - Ubuntu: `sudo apt-get install libgsl-dev`
 - Arch: `sudo pacman -S gsl`

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ For a list of changes, take a look at the [CHANGELOG](CHANGELOG.md).
 
 ## Installation
 
+### Requirements
+
+Rust-Bio-Tools depends on [GSL](https://www.gnu.org/software/gsl/) to be installed:
+
+- Ubuntu: `sudo apt-get install libgsl-dev`
+- Arch: `sudo pacman -S gsl`
+- OSX: `brew install gsl` 
+
 ### Bioconda
 
 Rust-Bio-Tools is available via [Bioconda](https://bioconda.github.io).


### PR DESCRIPTION
`cargo install rust-bio-tools` doesn't work without first installing gsl manually.