### PR TITLE
feat: anonymize bam - adapt mandatory and aux fields

### DIFF
--- a/src/bam/anonymize_reads.rs
+++ b/src/bam/anonymize_reads.rs
@@ -98,30 +98,17 @@ fn init_altered_bases(
 
 fn build_record(record: &bam::Record, artificial_seq: &[u8], offset: i64) -> Result<bam::Record> {
     let mut artificial_record = bam::record::Record::new();
-    for aux_result in record.aux_iter() {
-        let (tag, aux_field) = aux_result?;
-        artificial_record.push_aux(tag, aux_field)?;
-    }
     artificial_record.set(
         record.qname(),
         Some(&record.cigar()),
         artificial_seq,
         record.qual(),
     );
-    artificial_record.set_pos(record.pos() - offset);
-    artificial_record.set_tid(0);
-    let (mtid, mpos) = if record.mtid() == -1 {
-        (-1, 0)
-    } else if record.mtid() == record.tid() {
-        (0, record.mpos() - offset)
-    } else {
-        (1, record.mpos())
-    };
-    artificial_record.set_mtid(mtid);
-    artificial_record.set_mpos(mpos);
-    artificial_record.set_flags(record.flags());
-    artificial_record.set_insert_size(record.insert_size());
-    artificial_record.set_mapq(record.mapq());
+    set_mandatory_fields(&mut artificial_record, record, offset)?;
+    for aux_result in record.aux_iter() {
+        let (tag, aux_field) = aux_result?;
+        artificial_record.push_aux(tag, aux_field)?;
+    }
     Ok(artificial_record)
 }
 
@@ -175,6 +162,28 @@ fn build_sequence(
     }
 
     Ok(artificial_seq)
+}
+
+fn set_mandatory_fields(
+    target_rec: &mut bam::Record,
+    source_rec: &bam::Record,
+    offset: i64,
+) -> Result<()> {
+    target_rec.set_pos(source_rec.pos() - offset);
+    target_rec.set_tid(0);
+    let (mtid, mpos) = if source_rec.mtid() == -1 {
+        (-1, 0)
+    } else if source_rec.mtid() == source_rec.tid() {
+        (0, source_rec.mpos() - offset)
+    } else {
+        (1, source_rec.mpos())
+    };
+    target_rec.set_mtid(mtid);
+    target_rec.set_mpos(mpos);
+    target_rec.set_flags(source_rec.flags());
+    target_rec.set_insert_size(source_rec.insert_size());
+    target_rec.set_mapq(source_rec.mapq());
+    Ok(())
 }
 
 fn add_random_bases(

--- a/src/bam/anonymize_reads.rs
+++ b/src/bam/anonymize_reads.rs
@@ -110,10 +110,9 @@ fn build_record(record: &bam::Record, artificial_seq: &[u8], offset: i64) -> Res
     );
     artificial_record.set_pos(record.pos() - offset);
     artificial_record.set_tid(0);
-    let original_tid = record.tid();
     let (mtid, mpos) = if record.mtid() == -1 {
         (-1, 0)
-    } else if record.mtid() == original_tid {
+    } else if record.mtid() == record.tid() {
         (0, record.mpos() - offset)
     } else {
         (1, record.mpos())

--- a/src/bcf/match_variants.rs
+++ b/src/bcf/match_variants.rs
@@ -119,7 +119,6 @@ pub fn match_variants<P: AsRef<Path>>(matchbcf: P, max_dist: u32, max_len_diff: 
 #[derive(Debug)]
 pub struct Variant {
     id: u32,
-    rid: u32,
     pos: u64,
     alleles: Vec<VariantType>,
 }
@@ -206,7 +205,6 @@ impl Variant {
         };
         let var = Variant {
             id: *id,
-            rid: rec.rid().unwrap(),
             pos: pos as u64,
             alleles: _alleles,
         };

--- a/src/bcf/report/oncoprint.rs
+++ b/src/bcf/report/oncoprint.rs
@@ -985,8 +985,6 @@ struct Record {
     sample: String,
     gene: String,
     #[new(default)]
-    dna_alteration: Vec<String>,
-    #[new(default)]
     variants: Vec<String>,
 }
 

--- a/src/fastq/collapse_reads_to_fragments/pipeline.rs
+++ b/src/fastq/collapse_reads_to_fragments/pipeline.rs
@@ -63,7 +63,6 @@ fn isize_pmf(value: f64, mean: f64, sd: f64) -> LogProb {
 #[derive(Debug)]
 struct FastqStorage {
     db: DB,
-    storage_dir: std::path::PathBuf,
 }
 
 impl FastqStorage {
@@ -74,8 +73,7 @@ impl FastqStorage {
         // in turn deleting the tempdir
         let storage_dir = tempdir()?.path().join("db");
         Ok(FastqStorage {
-            db: DB::open_default(storage_dir.clone())?,
-            storage_dir,
+            db: DB::open_default(storage_dir)?,
         })
     }
 
@@ -351,11 +349,11 @@ impl<'a, R: io::Read + io::BufRead, W: io::Write> CallConsensusReads<'a, R, W>
     }
 
     fn fq1_reader(&mut self) -> &mut fastq::Reader<R> {
-        &mut self.fq1_reader
+        self.fq1_reader
     }
 
     fn fq2_reader(&mut self) -> &mut fastq::Reader<R> {
-        &mut self.fq2_reader
+        self.fq2_reader
     }
 
     fn umi_len(&self) -> usize {
@@ -506,11 +504,11 @@ impl<'a, R: io::Read + io::BufRead, W: io::Write> CallConsensusReads<'a, R, W>
     }
 
     fn fq1_reader(&mut self) -> &mut fastq::Reader<R> {
-        &mut self.fq1_reader
+        self.fq1_reader
     }
 
     fn fq2_reader(&mut self) -> &mut fastq::Reader<R> {
-        &mut self.fq2_reader
+        self.fq2_reader
     }
 
     fn umi_len(&self) -> usize {


### PR DESCRIPTION
This PR unifies the output of `bam-anonymize` by adapting the mandatory fields of the input file.
In addition, all aux fields are also copied to the anonymized reads in order to improve compatibility.

As there were some clippy warning about dead code these have been fixed.