### PR TITLE
feat: Use Feature before HGVSg for vcf-report level 1 naming

### DIFF
--- a/src/bcf/report/oncoprint.rs
+++ b/src/bcf/report/oncoprint.rs
@@ -174,6 +174,8 @@ pub fn oncoprint(
                             get_field("SYMBOL")?
                         } else if !get_field("Gene")?.is_empty() {
                             get_field("Gene")?
+                        } else if !get_field("Feature")?.is_empty() {
+                            get_field("Feature")?
                         } else if !get_field("HGVSg")?.is_empty() {
                             get_field("HGVSg")?
                         } else {


### PR DESCRIPTION
This PR changes makes the vcf-report use `Feature` before `HGVSg` for level 1 naming in case `Gene` and `SYMBOL` are missing.