### PR TITLE
feat: Add aux field to tooltip

### DIFF
--- a/src/bam/plot/bam_plot.html.tera
+++ b/src/bam/plot/bam_plot.html.tera
@@ -64,12 +64,57 @@
         let decompressed = LZString.decompressFromUTF16(plot);
         let unpacker = new jsonm.Unpacker();
         unpacker.setMaxDictSize(100000);
-        let unpacked_specs = unpacker.unpack(JSON.parse(decompressed));
-        unpacked_specs["width"] = $(window).width() - 100;
-        unpacked_specs["title"] = bams[i - 1];
-        decompressed_plots.push(unpacked_specs);
+        let specs = unpacker.unpack(JSON.parse(decompressed));
+        specs["width"] = $(window).width() - 100;
+        specs["title"] = bams[i - 1];
+        let aux_keys = new Set([]);
+        specs.data[1].values.forEach(function(a) {
+            if (a.row > 0) {
+                for (var key in a.aux) {
+                    aux_keys.add(key);
+                }
+                if (Array.isArray(a.flags)) {
+                    let flags = {};
+                    a.flags.forEach(function(b) {
+                        if (b === 1) {
+                            flags[b] = "template having multiple segments in sequencing";
+                        } else if (b === 2) {
+                            flags[b] = "each segment properly aligned according to the aligner";
+                        } else if (b === 4) {
+                            flags[b] = "segment unmapped";
+                        } else if (b === 8) {
+                            flags[b] = "next segment in the template unmapped";
+                        } else if (b === 16) {
+                            flags[b] = "SEQ being reverse complemented";
+                        } else if (b === 32) {
+                            flags[b] = "SEQ of the next segment in the template being reverse complemented";
+                        } else if (b === 64) {
+                            flags[b] = "the first segment in the template";
+                        } else if (b === 128) {
+                            flags[b] = "the last segment in the template";
+                        } else if (b === 256) {
+                            flags[b] = "secondary alignment";
+                        } else if (b === 512) {
+                            flags[b] = "not passing filters, such as platform/vendor quality controls";
+                        } else if (b === 1024) {
+                            flags[b] = "PCR or optical duplicate";
+                        } else if (b === 2048) {
+                            flags[b] = "vega lite lines";
+                        }
+                    });
+                    a.flags = flags;
+                }
+            }
+        });
+
+        let aux_tooltip = "";
+        for (var a of aux_keys) {
+            aux_tooltip = `${aux_tooltip},  \"${a}\": (datum[\"aux\"] || {})[\"${a}\"]`;
+        }
+        specs.marks[2].encode.update.tooltip.signal = specs.marks[2].encode.update.tooltip.signal.slice(0, -1) + aux_tooltip + "}";
+        decompressed_plots.push(specs);
         let plot_id = `#plot_${i}`;
-        vegaEmbed(plot_id, unpacked_specs);
+        vegaEmbed(plot_id, specs);
         i++;
     }
 

--- a/src/bcf/report/js/table-report.js
+++ b/src/bcf/report/js/table-report.js
@@ -25,44 +25,58 @@ $(document).ready(function () {
         let description = JSON.parse(d);
 
         for (let t = 1; t <= vis_len; t++) {
+            let aux_keys = new Set([]);
             let specs = $(this).data('vis' + t.toString());
             specs.data[1].values.forEach(function(a) {
-                if (a.row > 0 && Array.isArray(a.flags)) {
-                    let flags = {};
-                    a.flags.forEach(function(b) {
-                        if (b === 1) {
-                            flags[b] = "template having multiple segments in sequencing";
-                        } else if (b === 2) {
-                            flags[b] = "each segment properly aligned according to the aligner";
-                        } else if (b === 4) {
-                            flags[b] = "segment unmapped";
-                        } else if (b === 8) {
-                            flags[b] = "next segment in the template unmapped";
-                        } else if (b === 16) {
-                            flags[b] = "SEQ being reverse complemented";
-                        } else if (b === 32) {
-                            flags[b] = "SEQ of the next segment in the template being reverse complemented";
-                        } else if (b === 64) {
-                            flags[b] = "the first segment in the template";
-                        } else if (b === 128) {
-                            flags[b] = "the last segment in the template";
-                        } else if (b === 256) {
-                            flags[b] = "secondary alignment";
-                        } else if (b === 512) {
-                            flags[b] = "not passing filters, such as platform/vendor quality controls";
-                        } else if (b === 1024) {
-                            flags[b] = "PCR or optical duplicate";
-                        } else if (b === 2048) {
-                            flags[b] = "vega lite lines";
-                        }
-                    });
-                    a.flags = flags;
+                if (a.row > 0) {
+                    for (var key in a.aux) {
+                        aux_keys.add(key);
+                    }
+                    if (Array.isArray(a.flags)) {
+                        let flags = {};
+                        a.flags.forEach(function(b) {
+                            if (b === 1) {
+                                flags[b] = "template having multiple segments in sequencing";
+                            } else if (b === 2) {
+                                flags[b] = "each segment properly aligned according to the aligner";
+                            } else if (b === 4) {
+                                flags[b] = "segment unmapped";
+                            } else if (b === 8) {
+                                flags[b] = "next segment in the template unmapped";
+                            } else if (b === 16) {
+                                flags[b] = "SEQ being reverse complemented";
+                            } else if (b === 32) {
+                                flags[b] = "SEQ of the next segment in the template being reverse complemented";
+                            } else if (b === 64) {
+                                flags[b] = "the first segment in the template";
+                            } else if (b === 128) {
+                                flags[b] = "the last segment in the template";
+                            } else if (b === 256) {
+                                flags[b] = "secondary alignment";
+                            } else if (b === 512) {
+                                flags[b] = "not passing filters, such as platform/vendor quality controls";
+                            } else if (b === 1024) {
+                                flags[b] = "PCR or optical duplicate";
+                            } else if (b === 2048) {
+                                flags[b] = "vega lite lines";
+                            }
+                        });
+                        a.flags = flags;
+                    }
                 }
             });
+
+            let aux_tooltip = "";
+            for (var a of aux_keys) {
+                aux_tooltip = `${aux_tooltip},  \"${a}\": (datum[\"aux\"] || {})[\"${a}\"]`;
+            }
+            specs.marks[2].encode.update.tooltip.signal = specs.marks[2].encode.update.tooltip.signal.slice(0, -1) + aux_tooltip + "}";
             specs.title = 'Sample: ' + $(this).data('vis-sample' + t.toString());
             specs.width = $('#vis1').width() - 40;
             vegaEmbed('#vis' + t.toString(), specs);
         }
+
+
 
         $('.spinner-border').hide();
 

--- a/src/bcf/report/table_report/alignment_reader.rs
+++ b/src/bcf/report/table_report/alignment_reader.rs
@@ -4,12 +4,12 @@ use self::rust_htslib::bam::FetchDefinition;
 use crate::bcf::report::table_report::fasta_reader::read_fasta;
 use crate::common::Region;
 use anyhow::Result;
+use itertools::Itertools;
 use rust_htslib::bam::record::CigarStringView;
 use rust_htslib::{bam, bam::Read};
 use serde::Serialize;
-use std::path::Path;
-use itertools::Itertools;
 use std::collections::HashMap;
+use std::path::Path;
 
 #[derive(Serialize, Clone, Debug, PartialEq)]
 pub enum Marker {
@@ -37,7 +37,7 @@ pub struct Alignment {
     tid: i32,
     mate_tid: i32,
     mapq: u8,
-    aux: HashMap<String, String>
+    aux: HashMap<String, String>,
 }
 
 #[derive(Serialize, Clone, Debug, PartialEq)]
@@ -52,7 +52,7 @@ pub struct AlignmentNucleobase {
     pub read_end: u32,
     pub mapq: u8,
     pub cigar: String,
-    aux: HashMap<String, String>
+    aux: HashMap<String, String>,
 }
 
 #[derive(Serialize, Clone, Debug, PartialEq)]
@@ -66,7 +66,7 @@ pub struct AlignmentMatch {
     pub read_end: u32,
     pub mapq: u8,
     pub cigar: String,
-    aux: HashMap<String, String>
+    aux: HashMap<String, String>,
 }
 
 pub fn decode_flags(code: u16) -> Vec<u16> {
@@ -120,7 +120,11 @@ fn make_alignment(record: &bam::Record) -> Alignment {
     //Länge
     let le = record.seq().len() as u16;
 
-    let aux: HashMap<String, String> = record.aux_iter().map(|r| r.unwrap()).map(|(r,v)| (String::from_utf8(r.to_owned()).unwrap(), aux_to_string(v))).collect();
+    let aux: HashMap<String, String> = record
+        .aux_iter()
+        .map(|r| r.unwrap())
+        .map(|(r, v)| (String::from_utf8(r.to_owned()).unwrap(), aux_to_string(v)))
+        .collect();
 
     let seq = record.seq().as_bytes();
     let sequenz = String::from_utf8(seq).unwrap();
@@ -184,7 +188,7 @@ pub fn make_nucleobases<P: AsRef<Path> + std::fmt::Debug>(
                 read_end: (temp_snippet.mate_pos + 100) as u32,
                 mapq: snippet.mapq,
                 cigar: snippet.cigar.to_string(),
-                aux: snippet.aux.clone()
+                aux: snippet.aux.clone(),
             };
 
             matches.push(pairing);

--- a/src/bcf/report/table_report/alignment_reader.rs
+++ b/src/bcf/report/table_report/alignment_reader.rs
@@ -8,6 +8,8 @@ use rust_htslib::bam::record::CigarStringView;
 use rust_htslib::{bam, bam::Read};
 use serde::Serialize;
 use std::path::Path;
+use itertools::Itertools;
+use std::collections::HashMap;
 
 #[derive(Serialize, Clone, Debug, PartialEq)]
 pub enum Marker {
@@ -35,6 +37,7 @@ pub struct Alignment {
     tid: i32,
     mate_tid: i32,
     mapq: u8,
+    aux: HashMap<String, String>
 }
 
 #[derive(Serialize, Clone, Debug, PartialEq)]
@@ -49,6 +52,7 @@ pub struct AlignmentNucleobase {
     pub read_end: u32,
     pub mapq: u8,
     pub cigar: String,
+    aux: HashMap<String, String>
 }
 
 #[derive(Serialize, Clone, Debug, PartialEq)]
@@ -62,6 +66,7 @@ pub struct AlignmentMatch {
     pub read_end: u32,
     pub mapq: u8,
     pub cigar: String,
+    aux: HashMap<String, String>
 }
 
 pub fn decode_flags(code: u16) -> Vec<u16> {
@@ -115,7 +120,8 @@ fn make_alignment(record: &bam::Record) -> Alignment {
     //Länge
     let le = record.seq().len() as u16;
 
-    //Sequenz
+    let aux: HashMap<String, String> = record.aux_iter().map(|r| r.unwrap()).map(|(r,v)| (String::from_utf8(r.to_owned()).unwrap(), aux_to_string(v))).collect();
+
     let seq = record.seq().as_bytes();
     let sequenz = String::from_utf8(seq).unwrap();
 
@@ -139,6 +145,7 @@ fn make_alignment(record: &bam::Record) -> Alignment {
         tid,
         mate_tid: mtid,
         mapq: record.mapq(),
+        aux,
     }
 }
 
@@ -177,6 +184,7 @@ pub fn make_nucleobases<P: AsRef<Path> + std::fmt::Debug>(
                 read_end: (temp_snippet.mate_pos + 100) as u32,
                 mapq: snippet.mapq,
                 cigar: snippet.cigar.to_string(),
+                aux: snippet.aux.clone()
             };
 
             matches.push(pairing);
@@ -278,6 +286,7 @@ pub fn make_nucleobases<P: AsRef<Path> + std::fmt::Debug>(
                         read_end: re as u32,
                         mapq: snippet.mapq,
                         cigar: snippet.cigar.to_string(),
+                        aux: snippet.aux.clone(),
                     };
 
                     if from as f64 <= (base.start_position + 0.5)
@@ -323,6 +332,7 @@ pub fn make_nucleobases<P: AsRef<Path> + std::fmt::Debug>(
                             read_end: read_end as u32,
                             mapq: snippet.mapq,
                             cigar: snippet.cigar.to_string(),
+                            aux: snippet.aux.clone(),
                         };
 
                         read_offset += 1;
@@ -450,6 +460,7 @@ fn make_markers(
             read_end: read_end as u32,
             mapq: snip.mapq,
             cigar: snip.cigar.to_string(),
+            aux: snip.aux.clone(),
         });
     }
 
@@ -464,6 +475,7 @@ fn make_markers(
         read_end: read_end as u32,
         mapq: snip.mapq,
         cigar: snip.cigar.to_string(),
+        aux: snip.aux,
     };
     (mtch, base)
 }
@@ -498,5 +510,29 @@ fn end_mismatch_detection(snip: Alignment, match_start: i64, match_count: i64) -
         read_end: re as u32,
         mapq: snip.mapq,
         cigar: snip.cigar.to_string(),
+        aux: snip.aux,
+    }
+}
+
+fn aux_to_string(aux: rust_htslib::bam::record::Aux) -> String {
+    match aux {
+        rust_htslib::bam::record::Aux::Char(c) => String::from_utf8(vec![c]).unwrap(),
+        rust_htslib::bam::record::Aux::I8(i) => i.to_string(),
+        rust_htslib::bam::record::Aux::U8(i) => i.to_string(),
+        rust_htslib::bam::record::Aux::I16(i) => i.to_string(),
+        rust_htslib::bam::record::Aux::U16(i) => i.to_string(),
+        rust_htslib::bam::record::Aux::I32(i) => i.to_string(),
+        rust_htslib::bam::record::Aux::U32(i) => i.to_string(),
+        rust_htslib::bam::record::Aux::Float(i) => i.to_string(),
+        rust_htslib::bam::record::Aux::Double(i) => i.to_string(),
+        rust_htslib::bam::record::Aux::String(s) => s.to_owned(),
+        rust_htslib::bam::record::Aux::HexByteArray(i) => i.to_string(),
+        rust_htslib::bam::record::Aux::ArrayI8(a) => a.iter().join(","),
+        rust_htslib::bam::record::Aux::ArrayU8(a) => a.iter().join(","),
+        rust_htslib::bam::record::Aux::ArrayU16(a) => a.iter().join(","),
+        rust_htslib::bam::record::Aux::ArrayI16(a) => a.iter().join(","),
+        rust_htslib::bam::record::Aux::ArrayU32(a) => a.iter().join(","),
+        rust_htslib::bam::record::Aux::ArrayI32(a) => a.iter().join(","),
+        rust_htslib::bam::record::Aux::ArrayFloat(a) => a.iter().join(","),
     }
 }


### PR DESCRIPTION
This PR adds the aux field(s) of a bam record to the tooltip of any alignment plots generated with `rbt vcf-report` and `rbt plot-bam`. It also fixes the flags tooltip of `rbt plot-bam` that was not displayed correctly.