### PR TITLE
fix: add popper in csv report

### DIFF
--- a/src/csv/csv_report.html.tera
+++ b/src/csv/csv_report.html.tera
@@ -9,6 +9,7 @@
 </head>
 
 <body>
+<script src="../js/popper.min.js"></script>
 <script src="../js/jquery.min.js"></script>
 <script src="../js/bootstrap.bundle.min.js"></script>
 <script src="../js/bootstrap-table.min.js"></script>


### PR DESCRIPTION
 `Popper.js` is needed for popovers in bootstrap (see https://getbootstrap.com/docs/4.1/components/popovers/).

It should be included in `bootstrap.bundle.js`. However, in our reports over at [github.com/IKIM-Essen/uncovar](https://github.com/IKIM-Essen/uncovar) the popovers do not work (e.g., see 1. Overview -> 1. Report in a [report](https://github.com/IKIM-Essen/uncovar/suites/4921527977/artifacts/142056317) ). 
But if popper is included separately, the popovers are working.
