### PR TITLE
feat: Make annotation header available for customized reports

### DIFF
--- a/src/bcf/report/table_report/create_report_table.rs
+++ b/src/bcf/report/table_report/create_report_table.rs
@@ -419,6 +419,7 @@ pub(crate) fn make_table_report(
                     include_str!("report_table.html.tera"),
                 )?;
                 let mut context = Context::new();
+                context.insert("ann_description", &json!(ann_field_description).to_string());
                 context.insert("variant", &report_data);
                 context.insert("hgvsg", &hgvsg);
                 context.insert("escaped_hgvsg", &escaped_hgvsg);

--- a/src/bcf/report/table_report/report_table.html.tera
+++ b/src/bcf/report/table_report/report_table.html.tera
@@ -141,6 +141,9 @@
             </div>
         </div>
     </div>
-<script>$(document).ready(function () { $('#variant0').trigger('click');});</script>
+<script>
+    $(document).ready(function () { $('#variant0').trigger('click');});
+    const ANN_DESCRIPTION = {{ ann_description }};
+</script>
 </body>
 </html>

--- a/tests/expected/report/details/a/ENST00000557334_5_c_35G_A.html
+++ b/tests/expected/report/details/a/ENST00000557334_5_c_35G_A.html
@@ -502,6 +502,9 @@
             </div>
         </div>
     </div>
-<script>$(document).ready(function () { $('#variant0').trigger('click');});</script>
+<script>
+    $(document).ready(function () { $('#variant0').trigger('click');});
+    const ANN_DESCRIPTION = ["Allele","Consequence","IMPACT","SYMBOL","Gene","Feature_type","Feature","BIOTYPE","EXON","INTRON","HGVSg","HGVSp","cDNA_position","CDS_position","Protein_position","Amino_acids","Codons","Existing_variation","DISTANCE","STRAND","FLAGS","VARIANT_CLASS","SYMBOL_SOURCE","HGNC_ID","CANONICAL","MANE","TSL","APPRIS","CCDS","ENSP","SWISSPROT","TREMBL","UNIPARC","GENE_PHENO","SIFT","PolyPhen","DOMAINS","miRNA","HGVS_OFFSET","AF","AFR_AF","AMR_AF","EAS_AF","EUR_AF","SAS_AF","AA_AF","EA_AF","gnomAD_AF","gnomAD_AFR_AF","gnomAD_AMR_AF","gnomAD_ASJ_AF","gnomAD_EAS_AF","gnomAD_FIN_AF","gnomAD_NFE_AF","gnomAD_OTH_AF","gnomAD_SAS_AF","MAX_AF","MAX_AF_POPS","CLIN_SIG","SOMATIC","PHENO","PUBMED","MOTIF_NAME","MOTIF_POS","HIGH_INF_POS","MOTIF_SCORE_CHANGE","LoFtool"];
+</script>
 </body>
 </html>

--- a/tests/expected/report/details/b/ENST00000557334_5_c_35G_A.html
+++ b/tests/expected/report/details/b/ENST00000557334_5_c_35G_A.html
@@ -502,6 +502,9 @@
             </div>
         </div>
     </div>
-<script>$(document).ready(function () { $('#variant0').trigger('click');});</script>
+<script>
+    $(document).ready(function () { $('#variant0').trigger('click');});
+    const ANN_DESCRIPTION = ["Allele","Consequence","IMPACT","SYMBOL","Gene","Feature_type","Feature","BIOTYPE","EXON","INTRON","HGVSg","HGVSp","cDNA_position","CDS_position","Protein_position","Amino_acids","Codons","Existing_variation","DISTANCE","STRAND","FLAGS","VARIANT_CLASS","SYMBOL_SOURCE","HGNC_ID","CANONICAL","MANE","TSL","APPRIS","CCDS","ENSP","SWISSPROT","TREMBL","UNIPARC","GENE_PHENO","SIFT","PolyPhen","DOMAINS","miRNA","HGVS_OFFSET","AF","AFR_AF","AMR_AF","EAS_AF","EUR_AF","SAS_AF","AA_AF","EA_AF","gnomAD_AF","gnomAD_AFR_AF","gnomAD_AMR_AF","gnomAD_ASJ_AF","gnomAD_EAS_AF","gnomAD_FIN_AF","gnomAD_NFE_AF","gnomAD_OTH_AF","gnomAD_SAS_AF","MAX_AF","MAX_AF_POPS","CLIN_SIG","SOMATIC","PHENO","PUBMED","MOTIF_NAME","MOTIF_POS","HIGH_INF_POS","MOTIF_SCORE_CHANGE","LoFtool"];
+</script>
 </body>
 </html>


### PR DESCRIPTION
As @FelixMoelder pointed out accessing annotation fields via their index is getting very cumbersome since VEP mixes their order up now and then with new updates. This PR makes the header description available as a js array. This should make it easy to access every field without relying on VEPs ordering. Example:

```js
const ANN_DESCRIPTION = ["Allele","Consequence","IMPACT","SYMBOL","Gene","Feature_type","Feature","BIOTYPE","EXON","INTRON","HGVSc","HGVSp","cDNA_position","CDS_position","Protein_position","Amino_acids","Codons","Existing_variation","DISTANCE","STRAND","FLAGS","SYMBOL_SOURCE","HGNC_ID","SOURCE","HGVS_OFFSET","HGVSg","LoFtool","problematic-sites.vcf.gz","annotation.gff.gz"];
```
