### PR TITLE
fix: Improved message if error occurred during FORMAT parsing in vcf-to-txt

### DIFF
--- a/src/bcf/to_txt.rs
+++ b/src/bcf/to_txt.rs
@@ -198,7 +198,7 @@ pub fn to_txt(info_tags: &[&str], format_tags: &[&str], show_genotypes: bool) ->
 
                         match tag_type {
                             bcf::header::TagType::Flag => {
-                                panic!("there is no flag type for format");
+                                panic!("Unable to find FORMAT \"{}\" in the input file!", name);
                             }
                             bcf::header::TagType::Integer => {
                                 writer.write_field(

--- a/src/bcf/to_txt.rs
+++ b/src/bcf/to_txt.rs
@@ -198,7 +198,7 @@ pub fn to_txt(info_tags: &[&str], format_tags: &[&str], show_genotypes: bool) ->
 
                         match tag_type {
                             bcf::header::TagType::Flag => {
-                                panic!("Unable to find FORMAT \"{}\" in the input file!", name);
+                                panic!("Unable to find FORMAT \"{0}\" in the input file! Is \"{0}\" an INFO tag?", name);
                             }
                             bcf::header::TagType::Integer => {
                                 writer.write_field(

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -109,6 +109,21 @@ fn vcf_to_txt() {
 }
 
 #[test]
+// FIXME: can't work out how to use should_panic macro
+//#[should_panic]
+fn vcf_to_txt_input_info_as_format() {
+    assert!(String::from_utf8_lossy(
+        &Command::new("bash")
+            .arg("-c")
+            .arg("target/debug/rbt vcf-to-txt --fmt T < tests/test.vcf")
+            .output()
+            .unwrap()
+            .stderr
+    )
+    .contains("'Unable to find FORMAT \"T\" in the input file! Is \"T\" an INFO tag?'"));
+}
+
+#[test]
 fn vcf_match() {
     assert!(Command::new("bash")
             .arg("-c")


### PR DESCRIPTION
…to-txt

The tag name in FORMAT field that causes panic is now printed (#52).