### PR TITLE
feat: Remove duplicate marks from consensus records

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 uuid = { version = "0.7", features = ["v4"] }
 tempfile = "3.0"
-rocksdb = "0.17"
+rocksdb = "0.19"
 ordered-float = "0.5"
 flate2 = "1.0.5"
 streaming-stats =  "0.2.2"

--- a/src/bam/anonymize_reads.rs
+++ b/src/bam/anonymize_reads.rs
@@ -23,6 +23,7 @@ pub fn anonymize_reads<P: AsRef<Path> + std::fmt::Debug>(
     let mut fasta_reader = fasta::IndexedReader::from_file(&input_ref)?;
     fasta_reader.fetch(&chr, start, end)?;
     let mut reference = Vec::new();
+    reference.resize((end - start) as usize, 0);
     fasta_reader.read(&mut reference)?;
     let mut rng = rand::thread_rng();
     let alphabet = [b'A', b'C', b'G', b'T'];

--- a/src/bam/collapse_reads_to_fragments/mod.rs
+++ b/src/bam/collapse_reads_to_fragments/mod.rs
@@ -53,3 +53,11 @@ pub fn call_consensus_reads_from_paths<P: AsRef<Path>>(
     )
     .call_consensus_reads()
 }
+
+pub fn unmark_record(record: &mut bam::record::Record) -> Result<()> {
+    record.unset_duplicate();
+    let _ = record.remove_aux(b"PG");
+    let _ = record.remove_aux(b"DI");
+    let _ = record.remove_aux(b"DS");
+    Ok(())
+}


### PR DESCRIPTION
When calculating consensus reads it happens that reads get skipped and directly written into a bam file.
As skipped records are expected to be used in downstream analysis it may happen that these reads are marked as duplicates while the remaining duplicates got merged into a consensus read.
In that case the marked reads would be ignored by variant callers.
To prevent this from happening reads the duplicate-flag will be removed from skipped reads and also the PicardTools specific tags: `DI`, `DS` and `PG`. 