### PR TITLE
feat: reformat fastq header

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0"
 uuid = { version = "0.7", features = ["v4"] }
 tempfile = "3.0"
 rocksdb = "0.19"
-ordered-float = "0.5"
+ordered-float = "3.1"
 flate2 = "1.0.5"
 streaming-stats =  "0.2.2"
 GSL = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ thiserror = "1"
 rayon = "1.5"
 structopt = "0.3"
 lz-str = "0.1.0"
+handlebars = "4.3"
 
 [[bin]]
 name = "rbt"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -397,6 +397,25 @@ pub(crate) enum Command {
         )]
         fastq: bool,
     },
+    #[structopt(author = "Felix Mölder <felix.moelder@uni-due.de>")]
+    ReformatFastqHeader {
+        #[structopt(parse(from_os_str), help = "fastq file(s) to be reformated")]
+        fastqs: Vec<PathBuf>,
+        #[structopt(
+            long = "desc-regex",
+            short = "r",
+            value_name = "<regex>",
+            help = "regular expression of fastq description to be reformated"
+        )]
+        desc_regex: String,
+        #[structopt(
+            long = "desc-format",
+            short = "f",
+            value_name = "<target format>",
+            help = "target string utilizing regular expression for reformatting"
+        )]
+        desc_format: String,
+    },
 }
 
 #[derive(StructOpt)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -399,8 +399,6 @@ pub(crate) enum Command {
     },
     #[structopt(author = "Felix Mölder <felix.moelder@uni-due.de>")]
     ReformatFastqHeader {
-        #[structopt(parse(from_os_str), help = "fastq file(s) to be reformated")]
-        fastqs: Vec<PathBuf>,
         #[structopt(
             long = "desc-regex",
             short = "r",

--- a/src/common.rs
+++ b/src/common.rs
@@ -3,7 +3,7 @@ use approx::relative_eq;
 use bio::stats::probs::{LogProb, PHREDProb};
 use bio_types::sequence::SequenceRead;
 use itertools::Itertools;
-use ordered_float::NotNaN;
+use ordered_float::NotNan;
 use std::cmp;
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -56,7 +56,7 @@ pub trait CalcConsensus<'a, R: SequenceRead> {
             let (max_posterior, allele_lh) = likelihoods
                 .iter()
                 .enumerate()
-                .max_by_key(|&(_, &lh)| NotNaN::new(*lh).unwrap())
+                .max_by_key(|&(_, &lh)| NotNan::new(*lh).unwrap())
                 .unwrap();
             *consensus_lh += *allele_lh;
             let marginal = LogProb::ln_sum_exp(&likelihoods);

--- a/src/fastq/collapse_reads_to_fragments/pipeline.rs
+++ b/src/fastq/collapse_reads_to_fragments/pipeline.rs
@@ -3,7 +3,7 @@ use bio::io::fastq;
 use bio::io::fastq::{FastqRead, Record};
 use bio::stats::probs::LogProb;
 use derive_new::new;
-use ordered_float::NotNaN;
+use ordered_float::NotNan;
 use rgsl::randist::gaussian::ugaussian_P;
 use rocksdb::DB;
 use std::io;
@@ -442,7 +442,7 @@ impl<'a, R: io::Read, W: io::Write> CallOverlappingConsensusRead<'a, R, W> {
                     likelihood,
                 }
             })
-            .max_by_key(|consensus| NotNaN::new(*consensus.likelihood).unwrap())
+            .max_by_key(|consensus| NotNan::new(*consensus.likelihood).unwrap())
             .unwrap()
     }
 

--- a/src/fastq/mod.rs
+++ b/src/fastq/mod.rs
@@ -1,4 +1,5 @@
 //! Tools that work on FASTQ files
 pub mod collapse_reads_to_fragments;
 pub mod filter;
+pub mod reformat_fastq_header;
 pub mod split;

--- a/src/fastq/reformat_fastq_header.rs
+++ b/src/fastq/reformat_fastq_header.rs
@@ -28,26 +28,24 @@ fn process_fastq(desc_regex: &Regex, desc_format: &str, capture_groups: &[String
         let reg = Handlebars::new();
         let record = result?;
         let description_opt = record.desc();
-        let description_extended = match description_opt {
+        let description_updated = match description_opt {
             Some(description) => {
-                let mut description_extended = description.to_owned();
+                let mut description_updated = String::new();
                 for caps in desc_regex.captures_iter(description) {
                     let mut field_replacements = HashMap::new();
                     for field in capture_groups {
                         field_replacements.insert(field, caps.name(field).unwrap().as_str());
                     }
                     let rendered_entry = reg.render_template(desc_format, &field_replacements)?;
-                    //TODO That's dirty
-                    description_extended.push(' ');
-                    description_extended.push_str(&rendered_entry);
+                    description_updated = format!("{} {}", description_updated, rendered_entry);
                 }
-                Some(description_extended)
+                Some(description_updated)
             }
             None => None,
         };
         let record_out = fastq::Record::with_attrs(
             record.id(),
-            description_extended.as_deref(),
+            description_updated.as_deref(),
             record.seq(),
             record.qual(),
         );

--- a/src/fastq/reformat_fastq_header.rs
+++ b/src/fastq/reformat_fastq_header.rs
@@ -1,0 +1,100 @@
+use anyhow::Result;
+use bio::io::fastq;
+use flate2::bufread::MultiGzDecoder;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use regex::Regex;
+use std::fs;
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+
+fn writer<P: AsRef<Path>>(path: P) -> Result<fastq::Writer<Box<dyn std::io::Write>>> {
+    let w: Box<dyn Write> = if path.as_ref().extension().unwrap() == "gz" {
+        Box::new(
+            fs::File::create(&path)
+                .map(BufWriter::new)
+                .map(|w| GzEncoder::new(w, Compression::default()))?,
+        )
+    } else {
+        Box::new(fs::File::create(&path).map(BufWriter::new)?)
+    };
+    Ok(fastq::Writer::new(w))
+}
+
+fn reader<P: AsRef<Path>>(path: P) -> Result<fastq::Reader<BufReader<Box<dyn std::io::Read>>>> {
+    let r: Box<dyn Read> = if path.as_ref().extension().unwrap() == "gz" {
+        Box::new(
+            fs::File::open(&path)
+                .map(BufReader::new)
+                .map(MultiGzDecoder::new)?,
+        )
+    } else {
+        Box::new(fs::File::open(&path).map(BufReader::new)?)
+    };
+    Ok(fastq::Reader::new(r))
+}
+
+//TODO That is really bad for just adding a suffix to the file name
+fn build_fastq_out(fastq_in: &PathBuf) -> Result<PathBuf> {
+    let suffix = "reheadered.fastq.gz";
+    let mut fastq_out = if fastq_in.extension().unwrap() == "gz" {
+        fastq_in.to_str().unwrap().strip_suffix("fastq.gz").unwrap()
+    } else {
+        fastq_in.to_str().unwrap().strip_suffix("fastq").unwrap()
+    }
+    .to_owned();
+    fastq_out.push_str(suffix);
+    Ok(Path::new(&fastq_out).to_path_buf())
+}
+
+pub fn reformat_header(fastqs: Vec<PathBuf>, desc_regex: &str, desc_format: &str) -> Result<()> {
+    let regex = Regex::new(desc_regex)?;
+    let capture_groups = parse_format_fields(desc_regex)?;
+    for fastq in fastqs {
+        process_fastq(&fastq, &regex, desc_format, &capture_groups)?;
+    }
+    Ok(())
+}
+
+fn parse_format_fields(desc_regex: &str) -> Result<Vec<String>> {
+    let re = Regex::new("<([A-Za-z]+)>")?;
+    let caps = re.captures(desc_regex).unwrap();
+    let capture_fields: Vec<String> = (1..caps.len())
+        .map(|i| caps.get(i).unwrap().as_str().to_string())
+        .collect();
+    Ok(capture_fields)
+}
+
+fn process_fastq(
+    fastq_in: &PathBuf,
+    desc_regex: &Regex,
+    desc_format: &str,
+    capture_groups: &[String],
+) -> Result<()> {
+    let reader = reader(&fastq_in)?;
+    let fastq_out = build_fastq_out(fastq_in)?;
+    let mut writer = writer(fastq_out)?;
+    for result in reader.records() {
+        let record = result?;
+        let description_opt = record.desc();
+        let description_formatted = match description_opt {
+            Some(description) => {
+                let caps = desc_regex.captures(description).unwrap();
+                for caps in desc_regex.captures_iter(description) {
+                    dbg!(caps);
+                    //let desc_updated = format!(desc_format.to_string(), umi=caps.name("umi").unwrap());
+                }
+                None
+            }
+            None => None,
+        };
+        let record_out = fastq::Record::with_attrs(
+            record.id(),
+            description_formatted,
+            record.seq(),
+            record.qual(),
+        );
+        writer.write_record(&record_out)?;
+    }
+    Ok(())
+}

--- a/src/fastq/reformat_fastq_header.rs
+++ b/src/fastq/reformat_fastq_header.rs
@@ -14,9 +14,9 @@ pub fn reformat_header(desc_regex: &str, desc_format: &str) -> Result<()> {
 
 fn parse_format_fields(desc_regex: &str) -> Result<Vec<String>> {
     let re = Regex::new("<([A-Za-z]+)>")?;
-    let caps = re.captures(desc_regex).unwrap();
-    let capture_fields: Vec<String> = (1..caps.len())
-        .map(|i| caps.get(i).unwrap().as_str().to_string())
+    let capture_fields: Vec<String> = re
+        .captures_iter(desc_regex)
+        .map(|cap| cap.get(1).unwrap().as_str().to_string())
         .collect();
     Ok(capture_fields)
 }
@@ -37,8 +37,10 @@ fn process_fastq(desc_regex: &Regex, desc_format: &str, capture_groups: &[String
                         field_replacements.insert(field, caps.name(field).unwrap().as_str());
                     }
                     let rendered_entry = reg.render_template(desc_format, &field_replacements)?;
-                    description_updated = format!("{} {}", description_updated, rendered_entry);
+                    description_updated = format!("{}{} ", description_updated, rendered_entry);
                 }
+                //Remove trailing whitespace
+                description_updated.pop();
                 Some(description_updated)
             }
             None => None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -286,10 +286,9 @@ fn main() -> Result<()> {
         )?,
         SequenceStats { fastq } => sequences_stats::stats(fastq)?,
         ReformatFastqHeader {
-            fastqs,
             desc_regex,
             desc_format,
-        } => fastq::reformat_fastq_header::reformat_header(fastqs, &desc_regex, &desc_format)?,
+        } => fastq::reformat_fastq_header::reformat_header(&desc_regex, &desc_format)?,
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -285,6 +285,11 @@ fn main() -> Result<()> {
             keep_only_pairs,
         )?,
         SequenceStats { fastq } => sequences_stats::stats(fastq)?,
+        ReformatFastqHeader {
+            fastqs,
+            desc_regex,
+            desc_format,
+        } => fastq::reformat_fastq_header::reformat_header(fastqs, &desc_regex, &desc_format)?,
     }
     Ok(())
 }


### PR DESCRIPTION
This PR adds a new subcommand allowing to reformat the description of fastq records for fastq files.
For reformatting description entries following input is required:

- a regular expression with named capture group(s)
- a target string containing wildcards matching the named capture group(s)

The reformatted description entries will be added to the description leaving the original entries untouched.
The resulting records are written to std out.
