### PR TITLE
build: Update xlsxwriter due to compilation error with older version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ regex = "1.3"
 tera = "1"
 jsonm = "0.1.4"
 chrono = "0.4"
-xlsxwriter = {version = "0.3.5", features= ["use-openssl-md5", "no-md5"]}
+xlsxwriter = {version = "0.6", features= ["use-openssl-md5", "no-md5"]}
 lazy_static = "1.4"
 anyhow = "1"
 thiserror = "1"

--- a/src/csv/report.rs
+++ b/src/csv/report.rs
@@ -15,7 +15,7 @@ use std::io::{Read, Write};
 use std::path::Path;
 use std::str::FromStr;
 use tera::{Context, Tera};
-use xlsxwriter::*;
+use xlsxwriter::prelude::*;
 
 type LookupTable = HashMap<String, HashMap<String, Vec<(String, usize, usize)>>>;
 
@@ -127,7 +127,7 @@ pub(crate) fn csv_report(
         (_, _) => {}
     }
 
-    let wb = Workbook::new(&(output_path.to_owned() + "/report.xlsx"));
+    let wb = Workbook::new(&(output_path.to_owned() + "/report.xlsx"))?;
     let mut sheet = wb.add_worksheet(Some("Report"))?;
     for (i, title) in titles.iter().enumerate() {
         sheet.write_string(0, i.try_into()?, title, None)?;


### PR DESCRIPTION
This PR updates xlsxwriter due to compilation error with older version and fixes #256.